### PR TITLE
Perception publish tags as a world pose (#25)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -56,7 +56,7 @@ SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: false
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 0
+SpacesBeforeTrailingComments: 1
 SpacesInAngles: false
 SpacesInCStyleCastParentheses: false
 SpacesInContainerLiterals: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,10 +69,9 @@ catkin_python_setup()
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
 ## Generate messages in the 'msg' folder
-add_message_files(
-        FILES
-        MarkerInfo.msg
-)
+#add_message_files(
+#        FILES
+#)
 
 ## Generate services in the 'srv' folder
 # add_service_files(
@@ -89,10 +88,10 @@ add_message_files(
 # )
 
 ## Generate added messages and services with any dependencies listed here
- generate_messages(
-         DEPENDENCIES
-         std_msgs
- )
+generate_messages(
+        DEPENDENCIES
+        std_msgs
+)
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##
@@ -125,7 +124,7 @@ generate_dynamic_reconfigure_options(
 catkin_package(
         #  INCLUDE_DIRS include
         #  LIBRARIES mrover
-          CATKIN_DEPENDS roscpp rospy std_msgs message_runtime
+        CATKIN_DEPENDS roscpp rospy std_msgs message_runtime
         #  DEPENDS system_lib
 )
 
@@ -141,7 +140,8 @@ include_directories(
         ${OpenCV_INCLUDE_DIRS}
 )
 
-add_executable(aruco_detect src/perception/aruco_detect.cpp)
+file(GLOB_RECURSE PERCEPTION_SOURCES "src/perception/*.cpp")
+add_executable(aruco_detect ${PERCEPTION_SOURCES})
 add_dependencies(aruco_detect ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(aruco_detect ${catkin_LIBRARIES} ${OpenCV_LIBS})
 
@@ -211,11 +211,11 @@ install(DIRECTORY launch/
 
 ## Mark libraries for installation
 ## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_libraries.html
- install(TARGETS differential_drive_plugin_6w
-   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
- )
+install(TARGETS differential_drive_plugin_6w
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+        )
 
 ## Mark cpp header files for installation
 # install(DIRECTORY include/${PROJECT_NAME}/

--- a/launch/nav.launch
+++ b/launch/nav.launch
@@ -25,14 +25,18 @@
     -urdf -param robot_description
     -model rover" />
 
-  <!-- Perception-->
-  <node name="aruco_detect" pkg="mrover" type="aruco_detect">
-    <param name="publish_images" value="true" />
-    <param name="fiducial_len" value="0.20" />
-    <param name="dictionary" value="0" />
-  </node>
+  <!--
+    ==========
+    Perception
+    ==========
+  -->
+  <node name="aruco_detect" pkg="mrover" type="aruco_detect" />
 
-  <!-- Navigation -->
+  <!--
+    ===========
+    Navigation
+    ===========
+  -->
   <!-- This publishes the transforms of the course waypoints -->
   <node name="debug_course_publisher" pkg="mrover" type="debug_course_publisher.py" />
 

--- a/launch/percep.launch
+++ b/launch/percep.launch
@@ -25,12 +25,41 @@
     -urdf -param robot_description
     -model rover" />
 
-  <!-- Perception-->
-  <node name="aruco_detect" pkg="mrover" type="aruco_detect">
-    <param name="publish_images" value="true" />
-    <param name="fiducial_len" value="0.20" />
-    <param name="dictionary" value="0" /> <!-- DICT_4X4_50 -->
-    <remap from="camera" to="camera/color/image_raw" />
-    <remap from="camera_info" to="camera/color/camera_info" />
+  <!--
+    ==========
+    Perception
+    ==========
+  -->
+<!--   <node name="aruco_detect" pkg="mrover" type="aruco_detect" /> -->
+
+  <!--
+    ============
+    Localization
+    ============
+    Frames in the free tree:
+    odom: The topmost global frame
+    base_link: The rover
+  -->
+  <node name="mrover_localization" pkg="mrover" type="localization.py" />
+
+  <rosparam command="load" file="$(find mrover)/params/ekf_localization.yaml" />
+
+  <!-- Fuses together GPS position and IMU orientation with an Extended Kalman Filter (EKF) -->
+  <node pkg="robot_localization" type="ekf_localization_node" name="ekf_odom" clear_params="true">
+    <!-- Publications -->
+    <remap from="odometry/filtered" to="odometry/filtered" />
+  </node>
+
+  <!-- Reads the GPS topic and convert it to cartesian based on a reference point-->
+  <node pkg="robot_localization" type="navsat_transform_node" name="navsat_transform" clear_params="true">
+    <!-- Reference latitude/longitude to linearize from -->
+    <rosparam param="datum">[42.2, -83.7, 0.0, map, base_link]</rosparam>
+    <!-- Subscriptions -->
+    <remap from="imu/data" to="imu" />
+    <remap from="gps/fix" to="gps/fix" />
+    <remap from="odometry/filtered" to="odometry/filtered" />
+    <!-- Publications -->
+    <remap from="gps/filtered" to="gps/filtered" />
+    <remap from="odometry/gps" to="odometry/gps" />
   </node>
 </launch>

--- a/msg/MarkerInfo.msg
+++ b/msg/MarkerInfo.msg
@@ -1,4 +1,0 @@
-float64 distance1
-float64 bearing1
-float64 distance2
-float64 bearing2

--- a/src/gazebo/differential_drive_6w.cpp
+++ b/src/gazebo/differential_drive_6w.cpp
@@ -236,13 +236,13 @@ namespace gazebo {
 
         double vr, va;
 
-        vr = x_;   //myIface->data->cmdVelocity.pos.x;
-        va = -rot_;//myIface->data->cmdVelocity.yaw;
+        vr = x_;    //myIface->data->cmdVelocity.pos.x;
+        va = -rot_; //myIface->data->cmdVelocity.yaw;
 
         //std::cout << "X: [" << x_ << "] ROT: [" << rot_ << "]" << std::endl;
 
         // Changed motors to be always on, which is probably what we want anyway
-        enableMotors = true;//myIface->data->cmdEnableMotors > 0;
+        enableMotors = true; //myIface->data->cmdEnableMotors > 0;
 
         //std::cout << enableMotors << std::endl;
 
@@ -317,4 +317,4 @@ namespace gazebo {
 
     GZ_REGISTER_MODEL_PLUGIN(DiffDrivePlugin6W)
 
-}// namespace gazebo
+} // namespace gazebo

--- a/src/gazebo/differential_drive_6w.hpp
+++ b/src/gazebo/differential_drive_6w.hpp
@@ -29,8 +29,7 @@
  * Desc: ROS interface to a Position2d controller for a Differential drive.
  * Author: Daniel Hewlett (adapted from Nathan Koenig)
  */
-#ifndef DIFFDRIVE_PLUGIN_HH
-#define DIFFDRIVE_PLUGIN_HH
+#pragma once
 
 #include <map>
 
@@ -62,9 +61,9 @@ namespace gazebo {
         ~DiffDrivePlugin6W() override;
 
     protected:
-        virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+        void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) override;
 
-        virtual void Reset();
+        void Reset() override;
 
         virtual void Update();
 
@@ -120,6 +119,4 @@ namespace gazebo {
         event::ConnectionPtr updateConnection;
     };
 
-}// namespace gazebo
-
-#endif
+} // namespace gazebo

--- a/src/perception/README.md
+++ b/src/perception/README.md
@@ -1,0 +1,6 @@
+# [Perception](https://github.com/umrover/mrover-ros/wiki/Perception)
+
+### Code Layout
+
+- [aruco_detect.cpp](./aruco_detect.cpp) Mainly ROS node setup (topics, parameters, etc.)
+- [aruco_processing.cpp](./aruco_detect.cpp) Processes inputs (camera feed and pointcloud) to estimate locations of the ArUco fiducials

--- a/src/perception/aruco_detect.cpp
+++ b/src/perception/aruco_detect.cpp
@@ -28,466 +28,83 @@
  * policies, either expressed or implied, of the FreeBSD Project.
  *
  */
+
 #include "aruco_detect.hpp"
 
-
-using namespace std;
-using namespace cv;
-
-/**
-  * @brief Return object points for the system centered in a single marker, given the marker length
-  */
-static void getSingleMarkerObjectPoints(float markerLength, vector<Point3f>& objPoints) {
-
-    CV_Assert(markerLength > 0);
-
-    // set coordinate system in the middle of the marker, with Z pointing out
-    objPoints.clear();
-    objPoints.emplace_back(-markerLength / 2.f, markerLength / 2.f, 0);
-    objPoints.emplace_back(markerLength / 2.f, markerLength / 2.f, 0);
-    objPoints.emplace_back(markerLength / 2.f, -markerLength / 2.f, 0);
-    objPoints.emplace_back(-markerLength / 2.f, -markerLength / 2.f, 0);
-}
-
-// Euclidean distance between two points
-static double dist(const cv::Point2f& p1, const cv::Point2f& p2) {
-    double x1 = p1.x;
-    double y1 = p1.y;
-    double x2 = p2.x;
-    double y2 = p2.y;
-
-    double dx = x1 - x2;
-    double dy = y1 - y2;
-
-    return sqrt(dx * dx + dy * dy);
-}
-
-static cv::Point2f getTagCentroidFromCorners(fiducial_msgs::Fiducial fiducial) {
-    auto centerX = static_cast<float>((fiducial.x0 + fiducial.x1 + fiducial.x2 + fiducial.x3) / 4.0);
-    auto centerY = static_cast<float>((fiducial.y0 + fiducial.y1 + fiducial.y2 + fiducial.y3) / 4.0);
-    return {centerX, centerY};
-}
-
-// Compute area in image of a fiducial, using Heron's formula
-// to find the area of two triangles
-static double calcFiducialArea(const std::vector<cv::Point2f>& pts) {
-    const Point2f& p0 = pts.at(0);
-    const Point2f& p1 = pts.at(1);
-    const Point2f& p2 = pts.at(2);
-    const Point2f& p3 = pts.at(3);
-
-    double a1 = dist(p0, p1);
-    double b1 = dist(p0, p3);
-    double c1 = dist(p1, p3);
-
-    double a2 = dist(p1, p2);
-    double b2 = dist(p2, p3);
-    double c2 = c1;
-
-    double s1 = (a1 + b1 + c1) / 2.0;
-    double s2 = (a2 + b2 + c2) / 2.0;
-
-    a1 = sqrt(s1 * (s1 - a1) * (s1 - b1) * (s1 - c1));
-    a2 = sqrt(s2 * (s2 - a2) * (s2 - b2) * (s2 - c2));
-    return a1 + a2;
-}
-
-// estimate reprojection error
-static double getReprojectionError(const vector<Point3f>& objectPoints,
-                                   const vector<Point2f>& imagePoints,
-                                   const Mat& cameraMatrix, const Mat& distCoeffs,
-                                   const Vec3d& rvec, const Vec3d& tvec) {
-
-    vector<Point2f> projectedPoints;
-
-    cv::projectPoints(objectPoints, rvec, tvec, cameraMatrix,
-                      distCoeffs, projectedPoints);
-
-    // calculate RMS image error
-    double totalError = 0.0;
-    for (unsigned int i = 0; i < objectPoints.size(); i++) {
-        double error = dist(imagePoints[i], projectedPoints[i]);
-        totalError += error * error;
-    }
-    double reprojection_error = totalError / (double) objectPoints.size();
-    return reprojection_error;
-}
-
-void FiducialsNode::estimatePoseSingleMarkers(float markerLength,
-                                              const cv::Mat& cameraMatrix,
-                                              const cv::Mat& distCoeffs,
-                                              vector<Vec3d>& rvecs, vector<Vec3d>& tvecs,
-                                              vector<double>& reprojectionError) {
-
-    CV_Assert(markerLength > 0);
-
-    vector<Point3f> markerObjPoints;
-    int nMarkers = (int) corners.size();
-    rvecs.reserve(nMarkers);
-    tvecs.reserve(nMarkers);
-    reprojectionError.reserve(nMarkers);
-
-    // for each marker, calculate its pose
-    for (int i = 0; i < nMarkers; i++) {
-        double fiducialSize = markerLength;
-
-        auto it = fiducialLens.find(ids[i]);
-        if (it != fiducialLens.end()) {
-            fiducialSize = it->second;
-        }
-
-        getSingleMarkerObjectPoints(fiducialSize, markerObjPoints);
-        cv::solvePnP(markerObjPoints, corners[i], cameraMatrix, distCoeffs,
-                     rvecs[i], tvecs[i]);
-
-        reprojectionError[i] = getReprojectionError(markerObjPoints, corners[i],
-                                                    cameraMatrix, distCoeffs,
-                                                    rvecs[i], tvecs[i]);
-    }
-}
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
 
 void FiducialsNode::configCallback(mrover::DetectorParamsConfig& config, uint32_t level) {
-    /* Don't load initial config, since it will overwrite the rosparam settings */
+    // Don't load initial config, since it will overwrite the rosparam settings
     if (level == 0xFFFFFFFF) {
         return;
     }
 
-    detectorParams->adaptiveThreshConstant = config.adaptiveThreshConstant;
-    detectorParams->adaptiveThreshWinSizeMin = config.adaptiveThreshWinSizeMin;
-    detectorParams->adaptiveThreshWinSizeMax = config.adaptiveThreshWinSizeMax;
-    detectorParams->adaptiveThreshWinSizeStep = config.adaptiveThreshWinSizeStep;
-    detectorParams->cornerRefinementMaxIterations = config.cornerRefinementMaxIterations;
-    detectorParams->cornerRefinementMinAccuracy = config.cornerRefinementMinAccuracy;
-    detectorParams->cornerRefinementWinSize = config.cornerRefinementWinSize;
-#if CV_MINOR_VERSION == 2 and CV_MAJOR_VERSION == 3
-    detectorParams->doCornerRefinement = config.doCornerRefinement;
-#else
+    mDetectorParams->adaptiveThreshConstant = config.adaptiveThreshConstant;
+    mDetectorParams->adaptiveThreshWinSizeMin = config.adaptiveThreshWinSizeMin;
+    mDetectorParams->adaptiveThreshWinSizeMax = config.adaptiveThreshWinSizeMax;
+    mDetectorParams->adaptiveThreshWinSizeStep = config.adaptiveThreshWinSizeStep;
+    mDetectorParams->cornerRefinementMaxIterations = config.cornerRefinementMaxIterations;
+    mDetectorParams->cornerRefinementMinAccuracy = config.cornerRefinementMinAccuracy;
+    mDetectorParams->cornerRefinementWinSize = config.cornerRefinementWinSize;
     if (config.doCornerRefinement) {
         if (config.cornerRefinementSubpix) {
-            detectorParams->cornerRefinementMethod = aruco::CORNER_REFINE_SUBPIX;
+            mDetectorParams->cornerRefinementMethod = cv::aruco::CORNER_REFINE_SUBPIX;
         } else {
-            detectorParams->cornerRefinementMethod = aruco::CORNER_REFINE_CONTOUR;
+            mDetectorParams->cornerRefinementMethod = cv::aruco::CORNER_REFINE_CONTOUR;
         }
     } else {
-        detectorParams->cornerRefinementMethod = aruco::CORNER_REFINE_NONE;
+        mDetectorParams->cornerRefinementMethod = cv::aruco::CORNER_REFINE_NONE;
     }
-#endif
-    detectorParams->errorCorrectionRate = config.errorCorrectionRate;
-    detectorParams->minCornerDistanceRate = config.minCornerDistanceRate;
-    detectorParams->markerBorderBits = config.markerBorderBits;
-    detectorParams->maxErroneousBitsInBorderRate = config.maxErroneousBitsInBorderRate;
-    detectorParams->minDistanceToBorder = config.minDistanceToBorder;
-    detectorParams->minMarkerDistanceRate = config.minMarkerDistanceRate;
-    detectorParams->minMarkerPerimeterRate = config.minMarkerPerimeterRate;
-    detectorParams->maxMarkerPerimeterRate = config.maxMarkerPerimeterRate;
-    detectorParams->minOtsuStdDev = config.minOtsuStdDev;
-    detectorParams->perspectiveRemoveIgnoredMarginPerCell = config.perspectiveRemoveIgnoredMarginPerCell;
-    detectorParams->perspectiveRemovePixelPerCell = config.perspectiveRemovePixelPerCell;
-    detectorParams->polygonalApproxAccuracyRate = config.polygonalApproxAccuracyRate;
+    mDetectorParams->errorCorrectionRate = config.errorCorrectionRate;
+    mDetectorParams->minCornerDistanceRate = config.minCornerDistanceRate;
+    mDetectorParams->markerBorderBits = config.markerBorderBits;
+    mDetectorParams->maxErroneousBitsInBorderRate = config.maxErroneousBitsInBorderRate;
+    mDetectorParams->minDistanceToBorder = config.minDistanceToBorder;
+    mDetectorParams->minMarkerDistanceRate = config.minMarkerDistanceRate;
+    mDetectorParams->minMarkerPerimeterRate = config.minMarkerPerimeterRate;
+    mDetectorParams->maxMarkerPerimeterRate = config.maxMarkerPerimeterRate;
+    mDetectorParams->minOtsuStdDev = config.minOtsuStdDev;
+    mDetectorParams->perspectiveRemoveIgnoredMarginPerCell = config.perspectiveRemoveIgnoredMarginPerCell;
+    mDetectorParams->perspectiveRemovePixelPerCell = config.perspectiveRemovePixelPerCell;
+    mDetectorParams->polygonalApproxAccuracyRate = config.polygonalApproxAccuracyRate;
 }
 
-void FiducialsNode::ignoreCallback(const std_msgs::String& msg) {
-    ignoreIds.clear();
-    pnh.setParam("ignore_fiducials", msg.data);
+void FiducialsNode::ignoreCallback(std_msgs::String const& msg) {
+    mIgnoreIds.clear();
+    mPnh.setParam("ignore_fiducials", msg.data);
     handleIgnoreString(msg.data);
 }
 
-void FiducialsNode::camInfoCallback(const sensor_msgs::CameraInfo::ConstPtr& msg) {
-    if (haveCamInfo) {
+void FiducialsNode::camInfoCallback(sensor_msgs::CameraInfo::ConstPtr const& msg) {
+    if (mHasCamInfo) {
         return;
     }
 
     if (msg->K != boost::array<double, 9>({0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0})) {
         for (int i = 0; i < 3; i++) {
             for (int j = 0; j < 3; j++) {
-                cameraMatrix.at<double>(i, j) = msg->K[i * 3 + j];
+                mCamMat.at<double>(i, j) = msg->K[i * 3 + j];
             }
         }
 
         for (int i = 0; i < 5; i++) {
-            distortionCoeffs.at<double>(0, i) = msg->D[i];
+            mDistCoeffs.at<double>(0, i) = msg->D[i];
         }
 
-        haveCamInfo = true;
-        frameId = msg->header.frame_id;
+        mHasCamInfo = true;
+        mFrameId = msg->header.frame_id;
     } else {
         ROS_WARN("%s", "CameraInfo message has invalid intrinsics, K matrix all zeros");
     }
 }
 
-void FiducialsNode::imageCallback(const sensor_msgs::ImageConstPtr& msg) {
-    if (!enable_detections) {
-        return;//return without doing anything
-    }
-
-    if (verbose) {
-        ROS_INFO("Got image %d", msg->header.seq);
-    }
-
-    fiducial_msgs::FiducialArray fva;
-    fva.header.stamp = msg->header.stamp;
-    fva.header.frame_id = frameId;
-    fva.image_seq = static_cast<int>(msg->header.seq);
-
-    try {
-        cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
-
-        aruco::detectMarkers(cv_ptr->image, dictionary, corners, ids, detectorParams);
-
-        int detected_count = (int) ids.size();
-        if (verbose || detected_count != prev_detected_count) {
-            prev_detected_count = detected_count;
-            ROS_INFO("Detected %d markers", detected_count);
-        }
-
-        for (size_t i = 0; i < ids.size(); i++) {
-            if (std::count(ignoreIds.begin(), ignoreIds.end(), ids[i]) != 0) {
-                if (verbose) {
-                    ROS_INFO("Ignoring id %d", ids[i]);
-                }
-                continue;
-            }
-            fiducial_msgs::Fiducial fid;
-            fid.fiducial_id = ids[i];
-
-            fid.x0 = corners[i][0].x;
-            fid.y0 = corners[i][0].y;
-            fid.x1 = corners[i][1].x;
-            fid.y1 = corners[i][1].y;
-            fid.x2 = corners[i][2].x;
-            fid.y2 = corners[i][2].y;
-            fid.x3 = corners[i][3].x;
-            fid.y3 = corners[i][3].y;
-            fva.fiducials.push_back(fid);
-        }
-
-        vertices_pub.publish(fva);
-
-        if (fva.fiducials.empty()) {
-            // No tags found, return both tags as invalid
-            markerLocations.first.x = markerLocations.first.y = -1;
-            markerLocations.second.x = markerLocations.second.y = -1;
-        } else if (fva.fiducials.size() == 1) {
-            // One tag found, set second as invalid
-            markerLocations.first = getTagCentroidFromCorners(fva.fiducials[0]);
-            markerLocations.second.x = markerLocations.second.y = -1;
-        } else {
-            // Detected >= 2 tags
-            // If >= 3 tags, return the leftmost and rightmost detected tags
-            // to account for potentially seeing 2 of each tag on a post
-            vector<cv::Point2f> tagLocations;
-            tagLocations.reserve(fva.fiducials.size());
-            for (auto tag: fva.fiducials) {
-                tagLocations.push_back(getTagCentroidFromCorners(tag));
-            }
-            std::sort(tagLocations.begin(), tagLocations.end(),
-                      [](const auto& lhs, const auto& rhs) {
-                          return lhs.x < rhs.x;
-                      });
-            markerLocations.first = tagLocations[0];
-            markerLocations.second = tagLocations[tagLocations.size() - 1];
-        }
-
-        if (!ids.empty()) {
-            aruco::drawDetectedMarkers(cv_ptr->image, corners, ids);
-        }
-
-        if (publish_images) {
-            image_pub.publish(cv_ptr->toImageMsg());
-        }
-    } catch (cv_bridge::Exception& e) {
-        ROS_ERROR("cv_bridge exception: %s", e.what());
-    } catch (cv::Exception& e) {
-        ROS_ERROR("cv exception: %s", e.what());
-    }
-}
-
-std::pair<double, double> getDistAndBearingFromPointCloud(const sensor_msgs::PointCloud2ConstPtr& msg, int u, int v) {
-    // Could be done using PCL point clouds instead
-    size_t arrayPos = v * msg->row_step + u * msg->point_step;
-    size_t arrayPosX = arrayPos + msg->fields[0].offset;
-    size_t arrayPosY = arrayPos + msg->fields[1].offset;
-    size_t arrayPosZ = arrayPos + msg->fields[2].offset;
-
-    float x, y, z;
-    memcpy(&x, &msg->data[arrayPosX], sizeof(float));
-    memcpy(&y, &msg->data[arrayPosY], sizeof(float));
-    memcpy(&z, &msg->data[arrayPosZ], sizeof(float));
-
-    // Ensure xyz are valid
-    if (std::isnan(x) || std::isnan(y) || std::isnan(z)) return {-1, -1};
-
-    const float PI = 3.14159f;
-    double distance = std::sqrt(x * x + y * y + z * z);
-    double bearing = std::atan2(x, z) * 180.0 / PI;
-
-    return {distance, bearing};
-}
-
-void FiducialsNode::pointCloudCallback(const sensor_msgs::PointCloud2ConstPtr& msg) {
-    mrover::MarkerInfo detectedMarkerInfo;
-    detectedMarkerInfo.distance1 = detectedMarkerInfo.bearing1 = -1;
-    detectedMarkerInfo.distance2 = detectedMarkerInfo.bearing2 = -1;
-
-    if (markerLocations.first.x != -1 && markerLocations.first.y != -1) {
-        // Get the x/y/z from this point in the pointcloud
-        int x = static_cast<int>(std::lround(markerLocations.first.x));
-        int y = static_cast<int>(std::lround(markerLocations.first.y));
-        std::tie(detectedMarkerInfo.distance1, detectedMarkerInfo.bearing1) = getDistAndBearingFromPointCloud(msg, x, y);
-    }
-    if (markerLocations.second.x != -1 && markerLocations.second.y != -1) {
-        // Get the x/y/z from this point in the pointcloud
-        int x = static_cast<int>(std::lround(markerLocations.second.x));
-        int y = static_cast<int>(std::lround(markerLocations.second.y));
-        std::tie(detectedMarkerInfo.distance2, detectedMarkerInfo.bearing2) = getDistAndBearingFromPointCloud(msg, x, y);
-    }
-    markerInfo_pub.publish(detectedMarkerInfo);
-}
-
-void FiducialsNode::poseEstimateCallback(const FiducialArrayConstPtr& msg) {
-    vector<Vec3d> rvecs, tvecs;
-
-    vision_msgs::Detection2DArray vma;
-    fiducial_msgs::FiducialTransformArray fta;
-    if (vis_msgs) {
-        vma.header.stamp = msg->header.stamp;
-        vma.header.frame_id = frameId;
-        vma.header.seq = msg->header.seq;
-    } else {
-        fta.header.stamp = msg->header.stamp;
-        fta.header.frame_id = frameId;
-        fta.image_seq = static_cast<int>(msg->header.seq);
-    }
-    frameNum++;
-
-    if (doPoseEstimation) {
-        try {
-            if (!haveCamInfo) {
-                if (frameNum > 5) {
-                    ROS_ERROR("No camera intrinsics");
-                }
-                return;
-            }
-
-            vector<double> reprojectionError;
-            estimatePoseSingleMarkers((float) fiducial_len,
-                                      cameraMatrix, distortionCoeffs,
-                                      rvecs, tvecs,
-                                      reprojectionError);
-
-            for (size_t i = 0; i < ids.size(); i++) {
-                aruco::drawAxis(cv_ptr->image, cameraMatrix, distortionCoeffs,
-                                rvecs[i], tvecs[i], (float) fiducial_len);
-                if (verbose) {
-                    ROS_INFO("Detected id %d T %.2f %.2f %.2f R %.2f %.2f %.2f", ids[i],
-                             tvecs[i][0], tvecs[i][1], tvecs[i][2],
-                             rvecs[i][0], rvecs[i][1], rvecs[i][2]);
-                }
-
-                if (std::count(ignoreIds.begin(), ignoreIds.end(), ids[i]) != 0) {
-                    if (verbose) {
-                        ROS_INFO("Ignoring id %d", ids[i]);
-                    }
-                    continue;
-                }
-
-                double angle = norm(rvecs[i]);
-                Vec3d axis = rvecs[i] / angle;
-
-                if (verbose) {
-                    ROS_INFO("angle %f axis %f %f %f",
-                             angle, axis[0], axis[1], axis[2]);
-                }
-
-                double object_error =
-                        (reprojectionError[i] / dist(corners[i][0], corners[i][2])) *
-                        (norm(tvecs[i]) / fiducial_len);
-
-                // Standard ROS vision_msgs
-                fiducial_msgs::FiducialTransform ft;
-                tf2::Quaternion q;
-                if (vis_msgs) {
-                    vision_msgs::Detection2D vm;
-                    vision_msgs::ObjectHypothesisWithPose vmh;
-                    vmh.id = ids[i];
-                    vmh.score = exp(-2 * object_error);// [0, infinity] -> [1,0]
-                    vmh.pose.pose.position.x = tvecs[i][0];
-                    vmh.pose.pose.position.y = tvecs[i][1];
-                    vmh.pose.pose.position.z = tvecs[i][2];
-                    q.setRotation(tf2::Vector3(axis[0], axis[1], axis[2]), angle);
-                    vmh.pose.pose.orientation.w = q.w();
-                    vmh.pose.pose.orientation.x = q.x();
-                    vmh.pose.pose.orientation.y = q.y();
-                    vmh.pose.pose.orientation.z = q.z();
-
-                    vm.results.push_back(vmh);
-                    vma.detections.push_back(vm);
-                } else {
-                    ft.fiducial_id = ids[i];
-
-                    ft.transform.translation.x = tvecs[i][0];
-                    ft.transform.translation.y = tvecs[i][1];
-                    ft.transform.translation.z = tvecs[i][2];
-                    q.setRotation(tf2::Vector3(axis[0], axis[1], axis[2]), angle);
-                    ft.transform.rotation.w = q.w();
-                    ft.transform.rotation.x = q.x();
-                    ft.transform.rotation.y = q.y();
-                    ft.transform.rotation.z = q.z();
-                    ft.fiducial_area = calcFiducialArea(corners[i]);
-                    ft.image_error = reprojectionError[i];
-                    // Convert image_error (in pixels) to object_error (in meters)
-                    ft.object_error =
-                            (reprojectionError[i] / dist(corners[i][0], corners[i][2])) *
-                            (norm(tvecs[i]) / fiducial_len);
-
-                    fta.transforms.push_back(ft);
-                }
-
-                // Publish tf for the fiducial relative to the camera
-                if (publishFiducialTf) {
-                    if (vis_msgs) {
-                        geometry_msgs::TransformStamped ts;
-                        ts.transform.translation.x = tvecs[i][0];
-                        ts.transform.translation.y = tvecs[i][1];
-                        ts.transform.translation.z = tvecs[i][2];
-                        ts.transform.rotation.w = q.w();
-                        ts.transform.rotation.x = q.x();
-                        ts.transform.rotation.y = q.y();
-                        ts.transform.rotation.z = q.z();
-                        ts.header.frame_id = frameId;
-                        ts.header.stamp = msg->header.stamp;
-                        ts.child_frame_id = "fiducial_" + std::to_string(ids[i]);
-                        broadcaster.sendTransform(ts);
-                    } else {
-                        geometry_msgs::TransformStamped ts;
-                        ts.transform = ft.transform;
-                        ts.header.frame_id = frameId;
-                        ts.header.stamp = msg->header.stamp;
-                        ts.child_frame_id = "fiducial_" + std::to_string(ft.fiducial_id);
-                        broadcaster.sendTransform(ts);
-                    }
-                }
-            }
-        } catch (cv_bridge::Exception& e) {
-            ROS_ERROR("cv_bridge exception: %s", e.what());
-        } catch (cv::Exception& e) {
-            ROS_ERROR("cv exception: %s", e.what());
-        }
-    }
-    if (vis_msgs)
-        pose_pub.publish(vma);
-    else
-        pose_pub.publish(fta);
-}
-
-void FiducialsNode::handleIgnoreString(const std::string& str) {
-    /*
-    ignore fiducials can take comma separated list of individual
-    fiducial ids or ranges, eg "1,4,8,9-12,30-40"
-    */
+void FiducialsNode::handleIgnoreString(std::string const& str) {
+    // Ignore fiducials can take comma separated list of individual
+    // Fiducial ids or ranges, eg "1,4,8,9-12,30-40"
     std::vector<std::string> strs;
     boost::split(strs, str, boost::is_any_of(","));
-    for (const string& element: strs) {
+    for (const std::string& element: strs) {
         if (element.empty()) {
             continue;
         }
@@ -498,22 +115,21 @@ void FiducialsNode::handleIgnoreString(const std::string& str) {
             int end = std::stoi(range[1]);
             ROS_INFO("Ignoring fiducial id range %d to %d", start, end);
             for (int j = start; j <= end; j++) {
-                ignoreIds.push_back(j);
+                mIgnoreIds.push_back(j);
             }
         } else if (range.size() == 1) {
             int fid = std::stoi(range[0]);
             ROS_INFO("Ignoring fiducial id %d", fid);
-            ignoreIds.push_back(fid);
+            mIgnoreIds.push_back(fid);
         } else {
             ROS_ERROR("Malformed ignore_fiducials: %s", element.c_str());
         }
     }
 }
 
-bool FiducialsNode::enableDetectionsCallback(std_srvs::SetBool::Request& req,
-                                             std_srvs::SetBool::Response& res) {
-    enable_detections = req.data;
-    if (enable_detections) {
+bool FiducialsNode::enableDetectionsCallback(std_srvs::SetBool::Request& req, std_srvs::SetBool::Response& res) {
+    mEnableDetections = req.data;
+    if (mEnableDetections) {
         res.message = "Enabled aruco detections.";
         ROS_INFO("Enabled aruco detections.");
     } else {
@@ -525,137 +141,78 @@ bool FiducialsNode::enableDetectionsCallback(std_srvs::SetBool::Request& req,
     return true;
 }
 
-
-FiducialsNode::FiducialsNode() : nh(), pnh("~"), it(nh) {
-    frameNum = 0;
-    prev_detected_count = -1;
-
+FiducialsNode::FiducialsNode() : mNh(), mPnh("~"), mIt(mNh), mTfListener(mTfBuffer) {
     // Camera intrinsics
-    cameraMatrix = cv::Mat::zeros(3, 3, CV_64F);
-
+    mCamMat = cv::Mat::zeros(3, 3, CV_64F);
     // distortion coefficients
-    distortionCoeffs = cv::Mat::zeros(1, 5, CV_64F);
+    mDistCoeffs = cv::Mat::zeros(1, 5, CV_64F);
 
-    haveCamInfo = false;
-    enable_detections = true;
+    mDetectorParams = new cv::aruco::DetectorParameters();
 
-    int dicno;
-
-    detectorParams = new aruco::DetectorParameters();
-
-    pnh.param<bool>("publish_images", publish_images, true);
-    pnh.param<double>("fiducial_len", fiducial_len, 0.14);
-    pnh.param<int>("dictionary", dicno, 7);
-    pnh.param<bool>("do_pose_estimation", doPoseEstimation, false);
-    pnh.param<bool>("publish_fiducial_tf", publishFiducialTf, true);
-    pnh.param<bool>("vis_msgs", vis_msgs, false);
-    pnh.param<bool>("verbose", verbose, false);
+    int dicNo;
+    mPnh.param<bool>("publish_images", mPublishImages, true);
+    mPnh.param<double>("fiducial_len", mFiducialLen, 0.2);
+    mPnh.param<int>("dictionary", dicNo, 0);
+    mPnh.param<bool>("publish_fiducial_tf", mPublishFiducialTf, true);
+    mPnh.param<bool>("verbose", mIsVerbose, false);
 
     std::string str;
     std::vector<std::string> strs;
 
-    pnh.param<string>("ignore_fiducials", str, "");
+    mPnh.param<std::string>("ignore_fiducials", str, "");
     handleIgnoreString(str);
 
-    /*
-    fiducial size can take comma separated list of size: id or size: range,
-    e.g. "200.0: 12, 300.0: 200-300"
-    */
-    pnh.param<string>("fiducial_len_override", str, "");
-    boost::split(strs, str, boost::is_any_of(","));
-    for (const string& element: strs) {
-        if (element.empty()) {
-            continue;
-        }
-        std::vector<std::string> parts;
-        boost::split(parts, element, boost::is_any_of(":"));
-        if (parts.size() == 2) {
-            double len = std::stod(parts[1]);
-            std::vector<std::string> range;
-            boost::split(range, element, boost::is_any_of("-"));
-            if (range.size() == 2) {
-                int start = std::stoi(range[0]);
-                int end = std::stoi(range[1]);
-                ROS_INFO("Setting fiducial id range %d - %d length to %f",
-                         start, end, len);
-                for (int j = start; j <= end; j++) {
-                    fiducialLens[j] = len;
-                }
-            } else if (range.size() == 1) {
-                int fid = std::stoi(range[0]);
-                ROS_INFO("Setting fiducial id %d length to %f", fid, len);
-                fiducialLens[fid] = len;
-            } else {
-                ROS_ERROR("Malformed fiducial_len_override: %s", element.c_str());
-            }
-        } else {
-            ROS_ERROR("Malformed fiducial_len_override: %s", element.c_str());
-        }
-    }
+    mImgPub = mIt.advertise("fiducial_images", 1);
+    mFidPub = mNh.advertise<fiducial_msgs::FiducialTransformArray>("fiducial_transforms", 1);
+    mDictionary = cv::aruco::getPredefinedDictionary(dicNo);
 
-    image_pub = it.advertise("/fiducial_images", 1);
+    mImgSub = mIt.subscribe("camera/color/image_raw", 1, &FiducialsNode::imageCallback, this);
+    mPcSub = mNh.subscribe("camera/depth/points", 1, &FiducialsNode::pointCloudCallback, this);
+    mCamInfoSub = mNh.subscribe("camera/color/camera_info", 1, &FiducialsNode::camInfoCallback, this);
+    mIgnoreSub = mNh.subscribe("ignore_fiducials", 1, &FiducialsNode::ignoreCallback, this);
+    mServiceEnableDetections = mNh.advertiseService("enable_detections", &FiducialsNode::enableDetectionsCallback, this);
 
-    markerInfo_pub = nh.advertise<mrover::MarkerInfo>("marker_info", 1);
+    // Lambda handles passing class pointer (implicit first parameter) to configCallback
+    mCallbackType = [this](mrover::DetectorParamsConfig& config, uint32_t level) { configCallback(config, level); };
+    mConfigServer.setCallback(mCallbackType);
 
-    vertices_pub = nh.advertise<fiducial_msgs::FiducialArray>("fiducial_vertices", 1);
+    mPnh.param<double>("adaptiveThreshConstant", mDetectorParams->adaptiveThreshConstant, 7);
+    mPnh.param<int>("adaptiveThreshWinSizeMax", mDetectorParams->adaptiveThreshWinSizeMax, 53); /* default 23 */
+    mPnh.param<int>("adaptiveThreshWinSizeMin", mDetectorParams->adaptiveThreshWinSizeMin, 3);
+    mPnh.param<int>("adaptiveThreshWinSizeStep", mDetectorParams->adaptiveThreshWinSizeStep, 4); /* default 10 */
+    mPnh.param<int>("cornerRefinementMaxIterations", mDetectorParams->cornerRefinementMaxIterations, 30);
+    mPnh.param<double>("cornerRefinementMinAccuracy", mDetectorParams->cornerRefinementMinAccuracy, 0.01); /* default 0.1 */
+    mPnh.param<int>("cornerRefinementWinSize", mDetectorParams->cornerRefinementWinSize, 5);
 
-    if (vis_msgs)
-        pose_pub = nh.advertise<vision_msgs::Detection2DArray>("fiducial_transforms", 1);
-    else
-        pose_pub = nh.advertise<fiducial_msgs::FiducialTransformArray>("fiducial_transforms", 1);
-
-    dictionary = aruco::getPredefinedDictionary(dicno);
-
-    img_sub = it.subscribe("/camera/color/image_raw", 1, &FiducialsNode::imageCallback, this);
-
-    pc_sub = nh.subscribe("/camera/depth/points", 1, &FiducialsNode::pointCloudCallback, this);
-
-    vertices_sub = nh.subscribe("/fiducial_vertices", 1, &FiducialsNode::poseEstimateCallback, this);
-    caminfo_sub = nh.subscribe("/camera/color/camera_info", 1, &FiducialsNode::camInfoCallback, this);
-
-    ignore_sub = nh.subscribe("/ignore_fiducials", 1, &FiducialsNode::ignoreCallback, this);
-
-    service_enable_detections = nh.advertiseService("enable_detections", &FiducialsNode::enableDetectionsCallback, this);
-
-    callbackType = boost::bind(&FiducialsNode::configCallback, this, _1, _2);
-    configServer.setCallback(callbackType);
-
-    pnh.param<double>("adaptiveThreshConstant", detectorParams->adaptiveThreshConstant, 7);
-    pnh.param<int>("adaptiveThreshWinSizeMax", detectorParams->adaptiveThreshWinSizeMax, 53); /* default 23 */
-    pnh.param<int>("adaptiveThreshWinSizeMin", detectorParams->adaptiveThreshWinSizeMin, 3);
-    pnh.param<int>("adaptiveThreshWinSizeStep", detectorParams->adaptiveThreshWinSizeStep, 4); /* default 10 */
-    pnh.param<int>("cornerRefinementMaxIterations", detectorParams->cornerRefinementMaxIterations, 30);
-    pnh.param<double>("cornerRefinementMinAccuracy", detectorParams->cornerRefinementMinAccuracy, 0.01); /* default 0.1 */
-    pnh.param<int>("cornerRefinementWinSize", detectorParams->cornerRefinementWinSize, 5);
-#if CV_MINOR_VERSION == 2 and CV_MAJOR_VERSION == 3
-    pnh.param<bool>("doCornerRefinement", detectorParams->doCornerRefinement, true); /* default false */
-#else
     bool doCornerRefinement = true;
-    pnh.param<bool>("doCornerRefinement", doCornerRefinement, true);
+    mPnh.param<bool>("doCornerRefinement", doCornerRefinement, true);
     if (doCornerRefinement) {
         bool cornerRefinementSubPix = true;
-        pnh.param<bool>("cornerRefinementSubPix", cornerRefinementSubPix, true);
+        mPnh.param<bool>("cornerRefinementSubPix", cornerRefinementSubPix, true);
         if (cornerRefinementSubPix) {
-            detectorParams->cornerRefinementMethod = aruco::CORNER_REFINE_SUBPIX;
+            mDetectorParams->cornerRefinementMethod = cv::aruco::CORNER_REFINE_SUBPIX;
         } else {
-            detectorParams->cornerRefinementMethod = aruco::CORNER_REFINE_CONTOUR;
+            mDetectorParams->cornerRefinementMethod = cv::aruco::CORNER_REFINE_CONTOUR;
         }
     } else {
-        detectorParams->cornerRefinementMethod = aruco::CORNER_REFINE_NONE;
+        mDetectorParams->cornerRefinementMethod = cv::aruco::CORNER_REFINE_NONE;
     }
-#endif
-    pnh.param<double>("errorCorrectionRate", detectorParams->errorCorrectionRate, 0.6);
-    pnh.param<double>("minCornerDistanceRate", detectorParams->minCornerDistanceRate, 0.05);
-    pnh.param<int>("markerBorderBits", detectorParams->markerBorderBits, 1);
-    pnh.param<double>("maxErroneousBitsInBorderRate", detectorParams->maxErroneousBitsInBorderRate, 0.04);
-    pnh.param<int>("minDistanceToBorder", detectorParams->minDistanceToBorder, 3);
-    pnh.param<double>("minMarkerDistanceRate", detectorParams->minMarkerDistanceRate, 0.05);
-    pnh.param<double>("minMarkerPerimeterRate", detectorParams->minMarkerPerimeterRate, 0.1); /* default 0.3 */
-    pnh.param<double>("maxMarkerPerimeterRate", detectorParams->maxMarkerPerimeterRate, 4.0);
-    pnh.param<double>("minOtsuStdDev", detectorParams->minOtsuStdDev, 5.0);
-    pnh.param<double>("perspectiveRemoveIgnoredMarginPerCell", detectorParams->perspectiveRemoveIgnoredMarginPerCell, 0.13);
-    pnh.param<int>("perspectiveRemovePixelPerCell", detectorParams->perspectiveRemovePixelPerCell, 8);
-    pnh.param<double>("polygonalApproxAccuracyRate", detectorParams->polygonalApproxAccuracyRate, 0.01); /* default 0.05 */
+
+    mPnh.param<double>("errorCorrectionRate", mDetectorParams->errorCorrectionRate, 0.6);
+    mPnh.param<double>("minCornerDistanceRate", mDetectorParams->minCornerDistanceRate, 0.05);
+    mPnh.param<int>("markerBorderBits", mDetectorParams->markerBorderBits, 1);
+    mPnh.param<double>("maxErroneousBitsInBorderRate", mDetectorParams->maxErroneousBitsInBorderRate, 0.04);
+    mPnh.param<int>("minDistanceToBorder", mDetectorParams->minDistanceToBorder, 3);
+    mPnh.param<double>("minMarkerDistanceRate", mDetectorParams->minMarkerDistanceRate, 0.05);
+    mPnh.param<double>("minMarkerPerimeterRate", mDetectorParams->minMarkerPerimeterRate, 0.1); /* default 0.3 */
+    mPnh.param<double>("maxMarkerPerimeterRate", mDetectorParams->maxMarkerPerimeterRate, 4.0);
+    mPnh.param<double>("minOtsuStdDev", mDetectorParams->minOtsuStdDev, 5.0);
+    mPnh.param<double>("perspectiveRemoveIgnoredMarginPerCell", mDetectorParams->perspectiveRemoveIgnoredMarginPerCell, 0.13);
+    mPnh.param<int>("perspectiveRemovePixelPerCell", mDetectorParams->perspectiveRemovePixelPerCell, 8);
+    mPnh.param<double>("polygonalApproxAccuracyRate", mDetectorParams->polygonalApproxAccuracyRate, 0.01); /* default 0.05 */
+
+    mPnh.param<int>("filterCount", mFilterCount, 8);
+    mPnh.param<double>("filterProportion", mFilterProportion, 0.75);
 
     ROS_INFO("Aruco detection ready");
 }
@@ -663,9 +220,28 @@ FiducialsNode::FiducialsNode() : nh(), pnh("~"), it(nh) {
 int main(int argc, char** argv) {
     ros::init(argc, argv, "aruco_detect");
 
-    new boost::shared_ptr<FiducialsNode>{new FiducialsNode()};
+    [[maybe_unused]] auto node = std::make_unique<FiducialsNode>();
 
     ros::spin();
 
-    return 0;
+    return EXIT_SUCCESS;
+}
+
+void PersistentFiducial::addReading(SE3 const& fidInOdom) {
+    fidInOdomX.push(fidInOdom.x());
+    fidInOdomY.push(fidInOdom.y());
+    fidInOdomZ.push(fidInOdom.z());
+}
+
+void PersistentFiducial::setFilterParams(size_t count, double proportion) {
+    fidInOdomX.setFilterCount(count);
+    fidInOdomX.setProportion(static_cast<float>(proportion));
+    fidInOdomY.setFilterCount(count);
+    fidInOdomY.setProportion(static_cast<float>(proportion));
+    fidInOdomZ.setFilterCount(count);
+    fidInOdomZ.setProportion(static_cast<float>(proportion));
+}
+
+SE3 PersistentFiducial::getFidInOdom() const {
+    return {{fidInOdomX.get(), fidInOdomY.get(), fidInOdomZ.get()}, Eigen::Quaterniond::Identity()};
 }

--- a/src/perception/aruco_detect.hpp
+++ b/src/perception/aruco_detect.hpp
@@ -1,151 +1,111 @@
-/*
- * Copyright (c) 2017-20, Ubiquity Robotics Inc., Austin Hendrix
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
- * The views and conclusions contained in the software and documentation are
- * those of the authors and should not be interpreted as representing official
- * policies, either expressed or implied, of the FreeBSD Project.
- *
- */
-
-
-#include <cmath>
-#include <unistd.h>
+#include <optional>
+#include <string>
+#include <unordered_map>
 
 #include <cv_bridge/cv_bridge.h>
 #include <dynamic_reconfigure/server.h>
 #include <image_transport/image_transport.h>
-#include <ros/ros.h>
+#include <opencv2/aruco.hpp>
+#include <opencv2/core/mat.hpp>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <fiducial_msgs/FiducialTransformArray.h>
+#include <geometry_msgs/PoseStamped.h>
 #include <sensor_msgs/image_encodings.h>
 #include <sensor_msgs/point_cloud2_iterator.h>
 #include <std_msgs/String.h>
 #include <std_srvs/SetBool.h>
-#include <tf/transform_datatypes.h>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2_ros/transform_listener.h>
 
-#include "fiducial_msgs/Fiducial.h"
-#include "fiducial_msgs/FiducialArray.h"
-#include "fiducial_msgs/FiducialTransform.h"
-#include "fiducial_msgs/FiducialTransformArray.h"
-#include "mrover/DetectorParamsConfig.h"
+#include <mrover/DetectorParamsConfig.h>
 
-#include <vision_msgs/Detection2D.h>
-#include <vision_msgs/Detection2DArray.h>
-#include <vision_msgs/ObjectHypothesisWithPose.h>
+#include "filter.hpp"
+#include "se3.hpp"
 
-#include <opencv2/aruco.hpp>
-#include <opencv2/calib3d.hpp>
+constexpr char const* ODOM_FRAME = "odom";
+constexpr char const* ROVER_FRAME = "base_link";
 
-#include <boost/algorithm/string.hpp>
-#include <boost/shared_ptr.hpp>
-#include <list>
-#include <string>
+/**
+ * @brief Fiducials that are currently visible by the camera.
+ */
+struct ImmediateFiducial {
+    int id = -1;
+    cv::Point2f imageCenter{};
+    std::optional<SE3> fidInCam;
+};
 
-#include "mrover/MarkerInfo.h"
+/**
+ * @brief Filtered global positioning of fiducials that persist even when off screen.
+ */
+struct PersistentFiducial {
+    int id = -1;
+    MeanMedianFilter<double> fidInOdomX;
+    MeanMedianFilter<double> fidInOdomY;
+    MeanMedianFilter<double> fidInOdomZ;
 
-typedef boost::shared_ptr<fiducial_msgs::FiducialArray const> FiducialArrayConstPtr;
+    void setFilterParams(size_t count, double proportion);
+
+    void addReading(SE3 const& fidInOdom);
+
+    [[nodiscard]] SE3 getFidInOdom() const;
+};
 
 class FiducialsNode {
 private:
-    ros::NodeHandle nh;
-    ros::NodeHandle pnh;
+    ros::NodeHandle mNh;
+    ros::NodeHandle mPnh;
 
-    ros::Publisher vertices_pub;
-    ros::Publisher pose_pub;
+    ros::Publisher mFidPub;
+    image_transport::Publisher mImgPub;
+    ros::ServiceServer mServiceEnableDetections;
 
-    ros::Subscriber caminfo_sub;
-    ros::Subscriber vertices_sub;
-    ros::Subscriber ignore_sub;
-    image_transport::ImageTransport it;
-    image_transport::Subscriber img_sub;
-    ros::Subscriber pc_sub;
-    tf2_ros::TransformBroadcaster broadcaster;
+    ros::Subscriber mCamInfoSub;
+    ros::Subscriber mIgnoreSub;
+    ros::Subscriber mPcSub;
+    image_transport::Subscriber mImgSub;
+    image_transport::ImageTransport mIt;
+    tf2_ros::Buffer mTfBuffer;
+    tf2_ros::TransformListener mTfListener;
+    tf2_ros::TransformBroadcaster mTfBroadcaster;
 
-    ros::ServiceServer service_enable_detections;
+    bool mPublishImages = false; // If set, we publish the images with the fiducials drawn on top
+    bool mEnableDetections = true;
+    bool mIsVerbose = false;
+    bool mHasCamInfo = false;
+    bool mPublishFiducialTf = false;
+    double mFiducialLen{};
+    std::vector<int> mIgnoreIds;
+    int mFilterCount{};
+    double mFilterProportion{};
+    cv::Ptr<cv::aruco::DetectorParameters> mDetectorParams;
+    cv::Ptr<cv::aruco::Dictionary> mDictionary;
 
-    // if set, we publish the images that contain fiducials
-    bool publish_images;
-    bool enable_detections;
-    bool vis_msgs;
-    bool verbose;
+    uint32_t mSeqNum{};
+    cv_bridge::CvImagePtr mCvPtr;
+    cv::Mat mCamMat;
+    cv::Mat mDistCoeffs;
+    std::string mFrameId;
+    std::optional<size_t> mPrevDetectedCount; // Log spam prevention
+    std::vector<std::vector<cv::Point2f>> mCorners;
+    std::vector<int> mIds;
+    std::unordered_map<int, ImmediateFiducial> mImmediateFiducials;
+    std::unordered_map<int, PersistentFiducial> mPersistentFiducials;
+    dynamic_reconfigure::Server<mrover::DetectorParamsConfig> mConfigServer;
+    dynamic_reconfigure::Server<mrover::DetectorParamsConfig>::CallbackType mCallbackType;
 
-    double fiducial_len;
+    void handleIgnoreString(std::string const& str);
 
-    bool doPoseEstimation;
-    bool haveCamInfo;
-    bool publishFiducialTf;
-    std::vector<std::vector<cv::Point2f>> corners;
-    std::vector<int> ids;
-    cv_bridge::CvImagePtr cv_ptr;
+    void ignoreCallback(std_msgs::String const& msg);
 
-    cv::Mat cameraMatrix;
-    cv::Mat distortionCoeffs;
-    int frameNum;
-    std::string frameId;
-    std::vector<int> ignoreIds;
-    std::map<int, double> fiducialLens;
+    void imageCallback(sensor_msgs::ImageConstPtr const& msg);
 
-    image_transport::Publisher image_pub;
-    ros::Publisher markerInfo_pub;
+    void pointCloudCallback(sensor_msgs::PointCloud2ConstPtr const& msg);
 
-    // log spam prevention
-    int prev_detected_count;
-
-    cv::Ptr<cv::aruco::DetectorParameters> detectorParams;
-    cv::Ptr<cv::aruco::Dictionary> dictionary;
-
-    std::pair<cv::Point2f, cv::Point2f> markerLocations;
-
-    void handleIgnoreString(const std::string& str);
-
-    void estimatePoseSingleMarkers(float markerLength,
-                                   const cv::Mat& cameraMatrix,
-                                   const cv::Mat& distCoeffs,
-                                   std::vector<cv::Vec3d>& rvecs, std::vector<cv::Vec3d>& tvecs,
-                                   std::vector<double>& reprojectionError);
-
-
-    void ignoreCallback(const std_msgs::String& msg);
-
-    void imageCallback(const sensor_msgs::ImageConstPtr& msg);
-
-    void pointCloudCallback(const sensor_msgs::PointCloud2ConstPtr& msg);
-
-    void poseEstimateCallback(const FiducialArrayConstPtr& msg);
-
-    void camInfoCallback(const sensor_msgs::CameraInfo::ConstPtr& msg);
+    void camInfoCallback(sensor_msgs::CameraInfo::ConstPtr const& msg);
 
     void configCallback(mrover::DetectorParamsConfig& config, uint32_t level);
 
-    bool enableDetectionsCallback(std_srvs::SetBool::Request& req,
-                                  std_srvs::SetBool::Response& res);
-
-    dynamic_reconfigure::Server<mrover::DetectorParamsConfig> configServer;
-    dynamic_reconfigure::Server<mrover::DetectorParamsConfig>::CallbackType callbackType;
+    bool enableDetectionsCallback(std_srvs::SetBool::Request& req, std_srvs::SetBool::Response& res);
 
 public:
     FiducialsNode();

--- a/src/perception/aruco_processing.cpp
+++ b/src/perception/aruco_processing.cpp
@@ -1,0 +1,140 @@
+#include "aruco_detect.hpp"
+
+#include "filter.hpp"
+
+// TODO: add cache logic to filter out false positives
+
+/**
+ * Detect fiducials from raw image using OpenCV and calculate their screen space centers.
+ * Maintain the immediate buffer - holds all fiducials seen currently on screen.
+ * Later camera space pose information is filled in when we receive point cloud data.
+ *
+ * @param msg
+ */
+void FiducialsNode::imageCallback(sensor_msgs::ImageConstPtr const& msg) {
+    if (!mEnableDetections) return;
+
+    if (mIsVerbose) {
+        ROS_INFO("Got image %d", msg->header.seq);
+    }
+
+    try {
+        mCvPtr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
+
+        // Detect the fiducial vertices in screen space and their respective ids
+        cv::aruco::detectMarkers(mCvPtr->image, mDictionary, mCorners, mIds, mDetectorParams);
+
+        // Remove fiducials in the immediate buffer that are no longer in sight
+        auto it = mImmediateFiducials.begin();
+        while (it != mImmediateFiducials.end()) {
+            if (std::find(mIds.begin(), mIds.end(), it->first) == mIds.end()) {
+                it = mImmediateFiducials.erase(it);
+            } else {
+                ++it;
+            }
+        }
+
+        // Save fiducials currently on screen to the immediate buffer
+        for (size_t i = 0; i < mIds.size(); ++i) {
+            int id = mIds[i];
+            cv::Point2f imageCenter = std::accumulate(mCorners[i].begin(), mCorners[i].end(), cv::Point2f{}) / 4.0f;
+            ImmediateFiducial& immediateFid = mImmediateFiducials[id];
+            immediateFid.id = id;
+            immediateFid.imageCenter = imageCenter;
+        }
+
+        fiducial_msgs::FiducialTransformArray fidArray{};
+        fidArray.header.frame_id = ODOM_FRAME;
+        fidArray.header.stamp = ros::Time::now();
+        fidArray.header.seq = mSeqNum;
+        fidArray.transforms.reserve(mPersistentFiducials.size());
+
+        // Add readings to the persistent representations of the fiducials
+        for (auto [id, immediateFid]: mImmediateFiducials) {
+            PersistentFiducial& fid = mPersistentFiducials[id];
+            if (!immediateFid.fidInCam.has_value()) continue; // This is set if the point cloud had a valid reading for this fiducial
+
+            std::string immediateFrameName = "immediateFiducial" + std::to_string(id);
+            SE3::pushToTfTree(mTfBroadcaster, immediateFrameName, ROVER_FRAME, immediateFid.fidInCam.value());
+
+            fid.id = id;
+            try {
+                SE3 fidInOdom = SE3::fromTfTree(mTfBuffer, ODOM_FRAME, immediateFrameName);
+                fid.setFilterParams(mFilterCount, mFilterProportion);
+                fid.addReading(fidInOdom);
+            } catch (tf2::ExtrapolationException const&) {
+                ROS_WARN("Old data for immediate fiducial");
+            } catch (tf2::LookupException const&) {
+            }
+        }
+
+        // Send all transforms of persistent fiducials
+        for (auto [id, fid]: mPersistentFiducials) {
+            if (!fid.fidInOdomX.ready()) continue; // Wait until the filters have enough readings to become meaningful
+
+            SE3::pushToTfTree(mTfBroadcaster, "fiducial" + std::to_string(id), ODOM_FRAME, fid.getFidInOdom());
+        }
+
+        mFidPub.publish(fidArray);
+
+        size_t detectedCount = mIds.size();
+        if (mIsVerbose || !mPrevDetectedCount.has_value() || detectedCount != mPrevDetectedCount.value()) {
+            mPrevDetectedCount = detectedCount;
+            ROS_INFO("Detected %zu markers", detectedCount);
+        }
+
+        if (!mImmediateFiducials.empty()) {
+            cv::aruco::drawDetectedMarkers(mCvPtr->image, mCorners, mIds);
+        }
+
+        if (mPublishImages) {
+            mImgPub.publish(mCvPtr->toImageMsg());
+        }
+
+        mSeqNum++;
+    } catch (cv_bridge::Exception const& e) {
+        ROS_ERROR("cv_bridge exception: %s", e.what());
+    } catch (cv::Exception const& e) {
+        ROS_ERROR("cv exception: %s", e.what());
+    }
+}
+
+/**
+ * @brief       Retrieve the pose of the fiducial in camera space
+ * @param msg   3D Point Cloud with points stored relative to the camera
+ * @param u     X Pixel Position
+ * @param v     Y Pixel Position
+ */
+SE3 getFidInCamFromPixel(sensor_msgs::PointCloud2ConstPtr const& msg, size_t u, size_t v) {
+    // If PCL ends up being needed, use its camToPoint function instead
+    size_t arrayPos = v * msg->row_step + u * msg->point_step;
+    size_t arrayPosY = arrayPos + msg->fields[0].offset;
+    size_t arrayPosZ = arrayPos + msg->fields[1].offset;
+    size_t arrayPosX = arrayPos + msg->fields[2].offset;
+
+    cv::Point3f point;
+    std::memcpy(&point.x, &msg->data[arrayPosX], sizeof(point.x));
+    std::memcpy(&point.y, &msg->data[arrayPosY], sizeof(point.y));
+    std::memcpy(&point.z, &msg->data[arrayPosZ], sizeof(point.z));
+
+    return {{+point.x, -point.y, +point.z}, Eigen::Quaterniond::Identity()};
+}
+
+/**
+ * For each active fiducial image we have detected so far, fuse point cloud information.
+ * This information is where it is in the world.
+ *
+ * @param msg   Point cloud message
+ */
+void FiducialsNode::pointCloudCallback(sensor_msgs::PointCloud2ConstPtr const& msg) {
+    for (auto& [id, fid]: mImmediateFiducials) {
+        size_t u = std::lround(fid.imageCenter.x);
+        size_t v = std::lround(fid.imageCenter.y);
+
+        try {
+            fid.fidInCam = getFidInCamFromPixel(msg, u, v);
+        } catch (tf2::TransformException& ex) {
+            ROS_WARN("Transform lookup error: %s", ex.what());
+        }
+    }
+}

--- a/src/perception/filter.hpp
+++ b/src/perception/filter.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <numeric>
+#include <vector>
+
+/***
+ * A filter that combines multiple readings into one.
+ * A user defined proportion acts as a median filter that gets rids of outliers,
+ * which are then piped into a mean filter that averages out the values.
+ *
+ * @tparam T Reading type
+ */
+template<typename T>
+class MeanMedianFilter {
+private:
+    std::vector<T> mValues;
+    std::vector<T> mSortedValues;
+    // After sorting, what proportion in the middle values should we use.
+    double mProportion;
+    // How many readings we have.
+    // This will be capped at the capacity, since when we add when full we will overwrite the oldest value.
+    size_t mFilterCount = 0;
+    // Index to the current head.
+    // Note this is a circular buffer, so this will wrap around when we reach the end of the internal vector.
+    size_t mHead = 0;
+
+public:
+    MeanMedianFilter() : mValues(1), mProportion(0.0) {}
+
+    MeanMedianFilter(size_t size, double centerProportion) : mValues(size), mSortedValues(size), mProportion(centerProportion) {}
+
+    void setFilterCount(size_t filterCount) {
+        mValues.resize(filterCount);
+    }
+
+    void setProportion(float proportion) {
+        mProportion = proportion;
+    }
+
+    /**
+     * @brief Add a value to the filter, overwrites old values if full.
+     */
+    void push(T value) {
+        mHead = (mHead + 1) % size();
+        mValues[mHead] = value;
+        mFilterCount = std::min(mFilterCount + 1, size());
+        mSortedValues.assign(mValues.begin(), mValues.end());
+        std::sort(mSortedValues.begin(), mSortedValues.end());
+    }
+
+    void reset() {
+        mFilterCount = 0;
+    }
+
+    void decrementCount() {
+        mFilterCount = std::max(mFilterCount - 1, size_t{});
+    }
+
+    [[nodiscard]] size_t size() const {
+        return mValues.size();
+    }
+
+    [[nodiscard]] size_t filterCount() const {
+        return mFilterCount;
+    }
+
+    /***
+     * @return If we have enough readings to use the filter
+     */
+    [[nodiscard]] bool ready() const {
+        return mFilterCount > 0;
+    }
+
+    [[nodiscard]] bool full() const {
+        return mFilterCount == size();
+    }
+
+    /***
+     * @return Filtered reading if full, or else the most recent reading if we don't have enough readings yet.
+     */
+    [[nodiscard]] T get() const {
+        if (!full()) {
+            return mValues[mHead];
+        }
+        auto begin = mSortedValues.begin() + (mProportion * size() / 4);
+        auto end = mSortedValues.end() - (mProportion * size() / 4);
+        return std::accumulate(begin, end, T{}) / (end - begin);
+    }
+};

--- a/src/perception/se3.cpp
+++ b/src/perception/se3.cpp
@@ -1,0 +1,44 @@
+#include "se3.hpp"
+
+/**
+ *
+ * @param position
+ * @param rotation
+ */
+SE3::SE3(Eigen::Vector3d const& position, Eigen::Quaterniond const& rotation) : position(position), rotation(rotation) {
+}
+
+/**
+ *
+ * @param pose
+ * @return
+ */
+SE3 SE3::applyLeft(SE3 const& transform) {
+    auto affine = Eigen::Affine3d::Identity();
+    affine.translate(transform.position);
+    affine.rotate(transform.rotation);
+    return {affine * position, transform.rotation * rotation};
+}
+
+/**
+ *
+ * @param buffer
+ * @param fromFrameId
+ * @param toFrameId
+ * @return
+ */
+SE3 SE3::fromTfTree(tf2_ros::Buffer const& buffer, std::string const& fromFrameId, std::string const& toFrameId) {
+    geometry_msgs::TransformStamped transform = buffer.lookupTransform(fromFrameId, toFrameId, ros::Time(0));
+    return SE3::fromTf(transform.transform);
+}
+
+/**
+ *
+ * @param broadcaster
+ * @param childFrameId
+ * @param parentFrameId
+ * @param tf
+ */
+void SE3::pushToTfTree(tf2_ros::TransformBroadcaster& broadcaster, std::string const& childFrameId, std::string const& parentFrameId, SE3 const& tf) {
+    broadcaster.sendTransform(tf.toTransformStamped(parentFrameId, childFrameId));
+}

--- a/src/perception/se3.hpp
+++ b/src/perception/se3.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+#include <Eigen/Dense>
+
+class SE3 {
+private:
+    static SE3 fromTf(geometry_msgs::Transform const& transform);
+
+    static SE3 fromPose(geometry_msgs::Pose const& pose);
+
+    Eigen::Vector3d position;
+    Eigen::Quaterniond rotation;
+
+    [[nodiscard]] geometry_msgs::Pose toPose() const;
+
+    [[nodiscard]] geometry_msgs::Transform toTransform() const;
+
+    [[nodiscard]] geometry_msgs::PoseStamped toPoseStamped(std::string const& frameId) const;
+
+    [[nodiscard]] geometry_msgs::TransformStamped toTransformStamped(const std::string& parentFrameId, const std::string& childFrameId) const;
+
+public:
+    [[nodiscard]] static SE3 fromTfTree(tf2_ros::Buffer const& buffer, std::string const& fromFrameId, std::string const& toFrameId);
+
+    static void pushToTfTree(tf2_ros::TransformBroadcaster& broadcaster, std::string const& childFrameId, std::string const& parentFrameId, SE3 const& tf);
+
+    SE3() = default;
+
+    SE3(Eigen::Vector3d const& position, Eigen::Quaterniond const& rotation);
+
+    [[nodiscard]] SE3 applyLeft(SE3 const& transform);
+
+    [[nodiscard]] double x() const { return position.x(); }
+
+    [[nodiscard]] double y() const { return position.y(); }
+
+    [[nodiscard]] double z() const { return position.z(); }
+};

--- a/src/perception/se3_conversion.cpp
+++ b/src/perception/se3_conversion.cpp
@@ -1,0 +1,66 @@
+#include "se3.hpp"
+
+SE3 SE3::fromTf(geometry_msgs::Transform const& transform) {
+    SE3 se3;
+    se3.position.x() = transform.translation.x;
+    se3.position.y() = transform.translation.y;
+    se3.position.z() = transform.translation.z;
+    se3.rotation.x() = transform.rotation.x;
+    se3.rotation.y() = transform.rotation.y;
+    se3.rotation.z() = transform.rotation.z;
+    se3.rotation.w() = transform.rotation.w;
+    return se3;
+}
+
+SE3 SE3::fromPose(geometry_msgs::Pose const& pose) {
+    SE3 se3;
+    se3.position.x() = pose.position.x;
+    se3.position.y() = pose.position.y;
+    se3.position.z() = pose.position.z;
+    se3.rotation.x() = pose.orientation.x;
+    se3.rotation.y() = pose.orientation.y;
+    se3.rotation.z() = pose.orientation.z;
+    se3.rotation.w() = pose.orientation.w;
+    return se3;
+}
+
+geometry_msgs::Pose SE3::toPose() const {
+    geometry_msgs::Pose pose;
+    pose.position.x = position.x();
+    pose.position.y = position.y();
+    pose.position.z = position.z();
+    pose.orientation.x = rotation.x();
+    pose.orientation.y = rotation.y();
+    pose.orientation.z = rotation.z();
+    pose.orientation.w = rotation.w();
+    return pose;
+}
+
+geometry_msgs::Transform SE3::toTransform() const {
+    geometry_msgs::Transform transform;
+    transform.translation.x = position.x();
+    transform.translation.y = position.y();
+    transform.translation.z = position.z();
+    transform.rotation.x = rotation.x();
+    transform.rotation.y = rotation.y();
+    transform.rotation.z = rotation.z();
+    transform.rotation.w = rotation.w();
+    return transform;
+}
+
+geometry_msgs::PoseStamped SE3::toPoseStamped(std::string const& frameId) const {
+    geometry_msgs::PoseStamped pose;
+    pose.pose = toPose();
+    pose.header.frame_id = frameId;
+    pose.header.stamp = ros::Time::now();
+    return pose;
+}
+
+geometry_msgs::TransformStamped SE3::toTransformStamped(const std::string& parentFrameId, const std::string& childFrameId) const {
+    geometry_msgs::TransformStamped transform;
+    transform.transform = toTransform();
+    transform.header.frame_id = parentFrameId;
+    transform.header.stamp = ros::Time::now();
+    transform.child_frame_id = childFrameId;
+    return transform;
+}


### PR DESCRIPTION
* Refactor perception

* Continue working on sending tags as pose

* Remove marker msg, use vectors instead

* Rename member variables, move to using a struct

* Revert changes b/c clion thought it was too smart

* Use map instead of vector so we can keep track even if they go out of sight

* Fix launch files, remove dead code

* Split processing into separate file

* Add SE3, add filter, slightly modify clang format, restructure perception

* Filtered positioning for arucos in 3D space working, refactoring

* Fix formatting

* Refactor out SE3 transform function

* Add more to SE3, continue refactor

* Name median mean filter, cleanup se3 names

* Use eigen for implementation of se3

* Use tf tree instead of matrix multiplication

* Minor documentation

* Update README.md