### PR TITLE
Add custom resolutions per endpoint

### DIFF
--- a/config/cameras.yaml
+++ b/config/cameras.yaml
@@ -3,44 +3,51 @@ cameras:
         - resolution: 144
           arguments:
             - "--headless"
-              "--bitrate=300000"
-              "--width=256"
-              "--height=144"
+            - "--bitrate=300000"
+            - "--width=256"
+            - "--height=144"
         - resolution: 360
           arguments: 
             - "--headless"
-              "--bitrate=800000"
-              "--width=480"
-              "--height=360"
+            - "--bitrate=800000"
+            - "--width=480"
+            - "--height=360"
         - resolution: 720
           arguments:
             - "--headless"
-              "--bitrate=1800000"
-              "--width=1280"
-              "--height=720"
+            - "--bitrate=1800000"
+            - "--width=1280"
+            - "--height=720"
     default_mission: "erd"
     max_video_device_id_number: 10
     missions:
         - name: auton
-          ips:
-            - "10.0.0.1:5000"
-              "10.0.0.1:5001"
-          resolution: 144
+          streams:
+            - endpoint: "10.0.0.1:5000"
+              resolution: 144
+            - endpoint: "10.0.0.1:5001"
+              resolution: 144
         - name: erd
-          ips:
-            - "10.0.0.1:5000"
-              "10.0.0.1:5001"
-          resolution: 144
+          streams:
+            - endpoint: "10.0.0.1:5000"
+              resolution: 144
+            - endpoint: "10.0.0.1:5001"
+              resolution: 144
         - name: es
-          ips:
-            - "10.0.0.1:5000"
-              "10.0.0.1:5001"
-          resolution: 720
+          streams:
+            - endpoint: "10.0.0.1:5000"
+              resolution: 720
+            - endpoint: "10.0.0.1:5001"
+              resolution: 720
         - name: science
           ips:
-            - "10.0.0.1:5000"
-              "10.0.0.1:5001"
-              "10.0.0.2:5000"
-              "10.0.0.2:5001"
-          resolution: 144
+            streams:
+            - endpoint: "10.0.0.1:5000"
+              resolution: 144
+            - endpoint: "10.0.0.1:5001"
+              resolution: 144
+            - endpoint: "10.0.0.2:5000"
+              resolution: 144
+            - endpoint: "10.0.0.2:5001"
+              resolution: 144
     number_of_pipelines: 4

--- a/config/cameras.yaml
+++ b/config/cameras.yaml
@@ -23,31 +23,30 @@ cameras:
     missions:
         - name: auton
           streams:
-            - endpoint: "10.0.0.1:5000"
-              resolution: 144
-            - endpoint: "10.0.0.1:5001"
-              resolution: 144
+          - endpoint: "10.0.0.1:5000"
+            resolution: 144
+          - endpoint: "10.0.0.1:5001"
+            resolution: 144
         - name: erd
           streams:
-            - endpoint: "10.0.0.1:5000"
-              resolution: 144
-            - endpoint: "10.0.0.1:5001"
-              resolution: 144
+          - endpoint: "10.0.0.1:5000"
+            resolution: 144
+          - endpoint: "10.0.0.1:5001"
+            resolution: 144
         - name: es
           streams:
-            - endpoint: "10.0.0.1:5000"
-              resolution: 720
-            - endpoint: "10.0.0.1:5001"
-              resolution: 720
+          - endpoint: "10.0.0.1:5000"
+            resolution: 720
+          - endpoint: "10.0.0.1:5001"
+            resolution: 720
         - name: science
-          ips:
-            streams:
-            - endpoint: "10.0.0.1:5000"
-              resolution: 144
-            - endpoint: "10.0.0.1:5001"
-              resolution: 144
-            - endpoint: "10.0.0.2:5000"
-              resolution: 144
-            - endpoint: "10.0.0.2:5001"
-              resolution: 144
+          streams:
+          - endpoint: "10.0.0.1:5000"
+            resolution: 144
+          - endpoint: "10.0.0.1:5001"
+            resolution: 144
+          - endpoint: "10.0.0.2:5000"
+            resolution: 144
+          - endpoint: "10.0.0.2:5001"
+            resolution: 144
     number_of_pipelines: 4

--- a/src/esw/cameras/README.md
+++ b/src/esw/cameras/README.md
@@ -172,6 +172,7 @@ Actual behavior: The program freezes (presumably on the Capture function).
 ---
 
 ## TODO
+- [ ] Test the following: Test what happens when the one input device is being requested to be used for multiple output streams that differ in the resolution that it requests. Does the program fail and error?
 - [ ] Test the following: If an invalid device is being requested, does the response actually say -1 or does it not? Basically, does it only realize the device is invalid too late, as in after it sends the response?
 - [ ] Make sure that code makes logical sense... I'm reading through logic and head hurts
 - [ ] Test the exact behavior for when "user requests a camera that does not exist" and update README and optimize code.

--- a/src/esw/cameras/README.md
+++ b/src/esw/cameras/README.md
@@ -66,7 +66,7 @@ This determines up to which number we can look inside /dev/video*.
 #### Available Missions - cameras/missions
 
 You may choose to configure the available missions. Each mission has a name,
-a list of ips, and a resolution suited for the mission. You should not have more ips than
+a list of ips, and a resolution for each ip. You should not have more ips than
 the amount listed in number_of_pipelines (this will cause errors).
 
 #### Number of Pipelines - cameras/number_of_pipelines

--- a/src/esw/cameras/cameras.py
+++ b/src/esw/cameras/cameras.py
@@ -202,13 +202,6 @@ class PipelineManager:
 
     def _update_mission_ips_and_res_maps(self) -> None:
         """Fills in mission ips and resolutions maps from cameras.yaml
-        Returns nothing.
-
-        Args:
-            None.
-
-        Returns:
-            None.
         """
         self._mission_ips_map = {}
         self._mission_res_map = {}

--- a/src/esw/cameras/cameras.py
+++ b/src/esw/cameras/cameras.py
@@ -4,11 +4,11 @@
 
 The cameras codebase deals with managing the streams for the USB cameras on
 the rover. It manages messages that tell it which devices to stream, at which
-quality, and to which IPs.
+quality, and to which endpoints.
 
 """
 import sys
-from typing import List, TypedDict
+from typing import Dict, List
 
 import rospy
 from mrover.srv import (ChangeCameraMission, ChangeCameraMissionRequest,
@@ -28,7 +28,7 @@ class Pipeline:
 
     :var arguments: A list of strings that is needed for the jetson.utils
         objects' capture arguments.
-    :var current_ip: A string that is IP it is assigned to.
+    :var current_endpoint: A string that is endpoint it is assigned to.
     :var _device_number: An int that is the device number it is assigned to as
         its input. -1 means it is not assigned any device.
     :var _video_output: A jetson.utils.videoOutput object that holds its output
@@ -37,14 +37,14 @@ class Pipeline:
         source info.
     """
     arguments: List[str]
-    current_ip: str
+    current_endpoint: str
     _device_number: int
     _video_output: jetson.utils.videoOutput
     _video_source: jetson.utils.videoSource
 
     def __init__(self) -> None:
         self.arguments = []
-        self.current_ip = ""
+        self.current_endpoint = ""
         self.device_number = -1
         self._video_output = None
         self._video_source = None
@@ -100,16 +100,16 @@ class Pipeline:
             else:
                 print(
                     f"Unable to play camera {dev_index} on \
-                    {self.current_ip}."
+                    {self.current_endpoint}."
                 )
                 self.stop_streaming()
 
     def update_video_output(self) -> None:
         """Updates the video output to ensure that pipeline is streaming to
-        the assigned IP and has the proper arguments.
+        the assigned endpoint and has the proper arguments.
         """
         self._video_output = jetson.utils.videoOutput(
-            f"rtp://{self.current_ip}",
+            f"rtp://{self.current_endpoint}",
             argv=self.arguments
         )
 
@@ -120,15 +120,14 @@ class PipelineManager:
     :var _active_cameras: A list of integers that is the camera devices
         that are being streaming by each pipeline.
     :var _current_mission: A string that is the current mission. The
-        camera qualities and IPs depend on the mission.
+        camera qualities and endpoints depend on the mission.
     :var _default_mission: A string that is the default mission to fall
         back to.
     :var _max_vid_dev_id_number: An integer that is the maximum possible
         video devices connected to the Jetson. This determines up to which
         number we can look inside /dev/video*.
-    :var _mission_ips_map: A dictionary that maps each mission to an IP.
-    :var _mission_res_map: A dictionary that maps each mission to a resolution
-        quality.
+    :var _mission_streams_map: A dictionary that maps each mission to a list
+        of streams.
     :var _pipelines: A list of Pipeline objects that each manage the streaming
         of a device to an IP.
     :var _res_args_map: A dictionary that maps a resolution quality to a list
@@ -139,10 +138,9 @@ class PipelineManager:
     _current_mission: str
     _default_mission: str
     _max_vid_dev_id_number: int
-    _mission_ips_map: TypedDict[str, str]
-    _mission_res_map: TypedDict[str, int]
+    _mission_streams_map: 'Dict[str, List[Dict[str, str | int]]]'
     _pipelines: List[Pipeline]
-    _res_args_map: TypedDict[int, List[str]]
+    _res_args_map: Dict[int, List[str]]
     _video_sources: List[jetson.utils.videoSource]
 
     def __init__(self) -> None:
@@ -155,9 +153,9 @@ class PipelineManager:
         self._max_vid_dev_id_number = rospy.get_param(
             "cameras/max_video_device_id_number"
         )
+        self._mission_streams_map = {}
+        self._update_mission_streams_map()
 
-        self._update_mission_ips_and_res_maps()
-        
         self._current_mission = self._default_mission
         self._video_sources = [None] * self._max_vid_dev_id_number
         number_of_pipelines = rospy.get_param(
@@ -165,25 +163,20 @@ class PipelineManager:
         )
         self._pipelines = [None] * number_of_pipelines
         self._active_cameras = [-1] * number_of_pipelines
-        for pipeline_number in range(len(self._pipelines)):
-            self._pipelines[pipeline_number] = Pipeline()
+        for pipe_index in range(len(self._pipelines)):
+            self._pipelines[pipe_index] = Pipeline()
 
         self._update_all_resolution_arguments()
-        self._update_all_ips()
+        self._update_all_endpoints()
         self._update_all_video_outputs()
 
-    def _update_mission_ips_and_res_maps(self) -> None:
-        """Fills in mission ips and resolutions maps from cameras.yaml
+    def _update_mission_streams_map(self) -> None:
+        """Fills in mission endpoints and resolutions maps from cameras.yaml.
         """
-        self._mission_ips_map = {}
-        self._mission_res_map = {}
-        # missions_map: dict
-        for missions_map in rospy.get_param("cameras/missions"):
-            mission_name = missions_map['name']
-            # streams_map: list
-            for streams_map in missions_map['streams']:
-                self._mission_ips_map[mission_name] = streams_map['endpoint']
-                self._mission_res_map[mission_name] = missions_map['resolution']
+        for mission in rospy.get_param("cameras/missions"):
+            mission_name = mission['name']
+            streams = mission['streams']
+            self._mission_streams_map[mission_name] = streams
 
     def handle_change_camera_mission(
         self, req: ChangeCameraMissionRequest
@@ -202,7 +195,7 @@ class PipelineManager:
             return ChangeCameraMissionResponse(self._current_mission)
         self._update_mission(mission_name)
         self._update_all_resolution_arguments()
-        self._update_all_ips()
+        self._update_all_endpoints()
         self._update_all_video_outputs()
 
         return ChangeCameraMissionResponse(self._current_mission)
@@ -221,17 +214,17 @@ class PipelineManager:
             that pipeline.
         """
         requested_devices = req.cameras
-        for ip_number in range(len(self._get_all_ips())):
-            # enumerate through current_mission_ips because
-            # the length of current_mission_ips is always less
-            # than the length of requested_devices.
-            index = ip_number
-            requested_device = requested_devices[index]
-            if self._is_pipeline_streaming_device(requested_device, index):
+        for stream_index in range(len(self._get_all_streams())):
+            requested_device = requested_devices[stream_index]
+            if self._is_device_streamed_by_pipe(
+                requested_device, stream_index
+            ):
                 continue
-            self._close_device_of_pipeline_if_no_others_are_using(index)
-            self._create_video_source_if_possible(requested_device)
-            self._start_pipeline(requested_device, index)
+            self._close_device_of_pipeline_if_no_others_are_using(stream_index)
+            self._create_video_source_for_pipe_if_possible(
+                requested_device, stream_index
+            )
+            self._stream_device_on_pipe(requested_device, stream_index)
 
         self._update_active_cameras()
 
@@ -241,11 +234,11 @@ class PipelineManager:
         """Updates the stream for each pipeline. This means that in order to
         stream feed from a camera, this function must be constantly called.
         """
-        for pipeline_number, pipeline in enumerate(self._pipelines):
+        for pipe_index, pipeline in enumerate(self._pipelines):
             if pipeline.is_currently_streaming():
                 success = pipeline.capture_and_render_image()
                 if not success:
-                    self._clean_up_failed_pipeline(pipeline_number)
+                    self._clean_up_failed_pipeline(pipe_index)
 
     def _clean_up_failed_pipeline(self, pipe_index: int) -> None:
         """Cleans up a pipeline after its device has failed by unassigning it
@@ -253,10 +246,10 @@ class PipelineManager:
 
         :param pipe_index: the number of the pipeline that has failed.
         """
-        failed_device = pipe_index.device_number
+        failed_device = self._pipelines[pipe_index].device_number
         print(
             f"Camera {failed_device} capture \
-            on {self._get_ip(pipe_index)} \
+            on {self._get_endpoint(pipe_index)} \
             failed. Stopping stream."
         )
         # TODO(SASHREEK) - If others pipelines are using, you should
@@ -281,7 +274,7 @@ class PipelineManager:
         the device, nothing will happen.
 
         :param pipe_index: the number of the pipeline whose device is being
-        checked.
+            checked.
         """
         if self._pipeline_device_is_unique(pipe_index):
             pipeline_device_number = (
@@ -298,7 +291,9 @@ class PipelineManager:
         """
         self._video_sources[dev_index] = None
 
-    def _create_video_source_if_possible(self, dev_index: int) -> None:
+    def _create_video_source_for_pipe_if_possible(
+        self, dev_index: int, pipe_index: int
+    ) -> None:
         """Opens a connection to a video camera by creating the
         jetson.utils.videoSource.
 
@@ -308,6 +303,8 @@ class PipelineManager:
 
         :param dev_index: the number of the video camera device that is being
         opened.
+        :param pipe_index: An integer that is the number that the device is
+        intended to be streamed for.
         """
         if dev_index == -1:
             return
@@ -315,33 +312,54 @@ class PipelineManager:
             return
         try:
             self._video_sources[dev_index] = jetson.utils.videoSource(
-                f"/dev/video{dev_index}", argv=self._get_current_arguments()
+                f"/dev/video{dev_index}",
+                argv=self._get_pipe_arguments(pipe_index)
             )
         except Exception:
             return
 
-    def _get_all_ips(self) -> List[str]:
-        """Returns a list of all the ips.
+    def _get_all_streams(self) -> 'List[Dict[str, str | int]]':
+        """Returns a list of all the streams.
 
-        :return: A list of strings that represent the IPs for each pipeline.
+        :return: A list of dictionaries, where the list represents all the
+            streams.
         """
-        return self._mission_ips_map[self._current_mission]
+        return self._mission_streams_map[self._current_mission]
 
-    def _get_current_arguments(self) -> List[str]:
-        """Returns a list of the current arguments.
+    def _get_pipe_arguments(self, pipe_index: int) -> List[str]:
+        """Returns a list of the current arguments for the pipeline.
 
+        :param pipe_index: the number of the pipeline whose device is being
+            checked.
         :return: A list of strings that represent the arguments used to create
             the jetson.utils objects.
         """
-        quality = self._mission_res_map[self._current_mission]
+        streams = self._mission_streams_map[self._current_mission]
+        stream = streams[pipe_index]
+        quality = stream['resolution']
         return self._res_args_map[quality]
 
-    def _get_ip(self, pipe_index: int) -> str:
-        """Returns the ip of a pipeline.
+    def _get_stream(self, pipe_index: int) -> 'Dict[str, str | int]':
+        """Returns the stream of a pipeline.
         :param pipe_index: An integer that is the number of the pipeline.
-        :return: A string that that is the ip of the pipeline.
+        :return: A dictionary that that is the stream info of the pipeline.
         """
-        return self._get_all_ips()[pipe_index]
+        return self._get_all_streams()[pipe_index]
+
+    def _get_endpoint(self, pipe_index: int) -> str:
+        """Returns the endpoint of a pipeline.
+        :param pipe_index: An integer that is the number of the pipeline.
+        :return: A string that that is the endpoint of the pipeline.
+        """
+        return self._get_stream(pipe_index)['endpoint']
+
+    def _get_pipe_arguments(self, pipe_index: int) -> List[str]:
+        """Returns the resolution arguments of a pipeline.
+        :param pipe_index: An integer that is the number of the pipeline.
+        :return: A string that that is the resolution arguments of a pipeline.
+        """
+        resolution = self._get_stream(pipe_index)['resolution']
+        return self._res_args_map[resolution]
 
     def _is_mission_name_valid(self, mission_name: str) -> bool:
         """Returns True if the mission_name is valid.
@@ -351,20 +369,20 @@ class PipelineManager:
         :return: A boolean that tells if the mission name is valid.
         """
         assert mission_name.islower(), "mission_name should be lower case"
-        return mission_name in self._mission_res_map.keys()
+        return mission_name in self._mission_streams_map.keys()
 
-    def _is_pipeline_streaming_device(
-        self, pipe_index: int, device: int
+    def _is_device_streamed_by_pipe(
+        self, dev_index: int, pipe_index: int
     ) -> bool:
         """Returns True if the pipeline is streaming the device.
 
         :param pipe_index: An integer that is the number of the pipeline.
-        :param device: The number of the camera device.
+        :param dev_index: The number of the camera device.
         :return: A boolean that tells if the pipeline is currently streaming
             the device.
         """
         pipeline_device_number = self._pipelines[pipe_index].device_number
-        return pipeline_device_number == device
+        return pipeline_device_number == dev_index
 
     def _pipeline_device_is_unique(self, excluded_pipe_index: int) -> bool:
         """Returns True if no other pipelines are streaming the same device as
@@ -377,14 +395,14 @@ class PipelineManager:
             the device.
         """
         device_number = self._pipelines[excluded_pipe_index].device_number
-        for pipeline_number, pipeline in enumerate(self._pipelines):
-            if pipeline_number == excluded_pipe_index:
+        for pipe_index, pipeline in enumerate(self._pipelines):
+            if pipe_index == excluded_pipe_index:
                 continue
             if pipeline.device_number == device_number:
                 return False
         return True
 
-    def _start_pipeline(self, dev_index: int, pipe_index: int) -> None:
+    def _stream_device_on_pipe(self, dev_index: int, pipe_index: int) -> None:
         """Assigns a camera device a pipeline.
 
         :param dev_index: An integer that is the assigned camera device.
@@ -396,7 +414,7 @@ class PipelineManager:
         )
         print(
             f"Playing camera {dev_index} on \
-            {self._get_ip(pipe_index)}."
+            {self._get_endpoint(pipe_index)}."
         )
 
     def _update_active_cameras(self) -> None:
@@ -406,37 +424,36 @@ class PipelineManager:
         for index, pipeline in enumerate(self._pipelines):
             self._active_cameras[index] = pipeline.device_number
 
-    def _update_all_ips(self) -> None:
-        """Updates the IPs to what is currently being requested.
+    def _update_all_endpoints(self) -> None:
+        """Updates the endpoints  to what is currently being requested.
 
         Only skip if 0 or 1 because it's the same either way.
         NOTE: This is an optimization trick made because of how we made the
         camera system on the rover. This may change in the future if we decide
         to make the first two ips different per mission.
         """
-        for pipeline_number, pipeline in enumerate(self._pipelines):
-            if pipeline_number == 0 or pipeline_number == 1:
+        for pipe_index, pipeline in enumerate(self._pipelines):
+            if pipe_index == 0 or pipe_index == 1:
                 continue
-            pipeline.current_ip = self._get_ip(pipeline_number)
+            pipeline.current_endpoint = self._get_endpoint(pipe_index)
 
     def _update_all_resolution_arguments(self) -> None:
         """Updates the video resolutions to what is currently being requested.
         """
-        current_arguments = self._get_current_arguments()
-        for pipeline in self._pipelines:
-            pipeline.arguments = current_arguments
+        for pipe_number, pipeline in enumerate(self._pipelines):
+            pipeline.arguments = self._get_pipe_arguments(pipe_number)
 
     def _update_all_video_outputs(self) -> None:
-        """Updates the video outputs and IPs and video resolutions to what is
-        currently being requested.
+        """Updates the video outputs and endpoints and video resolutions to
+        what is currently being requested.
 
         Only skip if 0 or 1 because it's the same either way.
         NOTE: This is an optimization trick made because of how we made the
         camera system on the rover. This may change in the future if we decide
-        to make the first two ips different per mission.
+        to make the first two endpoints different per mission.
         """
-        for pipeline_number, pipeline in enumerate(self._pipelines):
-            if pipeline_number == 0 or pipeline_number == 1:
+        for pipe_index, pipeline in enumerate(self._pipelines):
+            if pipe_index == 0 or pipe_index == 1:
                 continue
             pipeline.update_video_output()
 

--- a/src/esw/cameras/cameras.py
+++ b/src/esw/cameras/cameras.py
@@ -88,7 +88,8 @@ class Pipeline:
         camera device does not exist or if the request is -1, it will not be
         assigned a device.
 
-        :param dev_index: An int that is the camera device that it is assigned.
+        :param dev_index: An integer that is the camera device that it is
+            assigned.
         :param video_sources: A jetson.utils.videoSource that it will be
         streaming from. This may be None.
         """
@@ -244,7 +245,8 @@ class PipelineManager:
         """Cleans up a pipeline after its device has failed by unassigning it
         to a device and safely closing the stream and the video source.
 
-        :param pipe_index: the number of the pipeline that has failed.
+        :param pipe_index: An integer that is the number of the pipeline that
+            has failed.
         """
         failed_device = self._pipelines[pipe_index].device_number
         print(
@@ -269,8 +271,8 @@ class PipelineManager:
         are using the device, then it is safely cleaned. If others are using
         the device, nothing will happen.
 
-        :param pipe_index: the number of the pipeline whose device is being
-            checked.
+        :param pipe_index: An integer that is the number of the pipeline whose
+            device is being checked.
         """
         if self._pipeline_device_is_unique(pipe_index):
             pipeline_device_number = (
@@ -282,8 +284,8 @@ class PipelineManager:
         """Closes the connection to a video camera by deleting the
         jetson.utils.videoSource.
 
-        :param dev_index: the number of the video camera device that is being
-        closed.
+        :param dev_index: An integer that is the number of the video camera
+            device that is being closed.
         """
         self._video_sources[dev_index] = None
 
@@ -297,10 +299,10 @@ class PipelineManager:
         caught and the program resumes. The only effect is that the
         videoSource is not made.
 
-        :param dev_index: the number of the video camera device that is being
-        opened.
+        :param dev_index: An integer that is the number of the video camera
+            device that is being opened.
         :param pipe_index: An integer that is the number that the device is
-        intended to be streamed for.
+            intended to be streamed for.
         """
         if dev_index == -1:
             return
@@ -325,8 +327,8 @@ class PipelineManager:
     def _get_pipe_arguments(self, pipe_index: int) -> List[str]:
         """Returns a list of the current arguments for the pipeline.
 
-        :param pipe_index: the number of the pipeline whose device is being
-            checked.
+        :param pipe_index: An integer that is the number of the pipeline whose
+            device is being checked.
         :return: A list of strings that represent the arguments used to create
             the jetson.utils objects.
         """
@@ -373,7 +375,7 @@ class PipelineManager:
         """Returns True if the pipeline is streaming the device.
 
         :param pipe_index: An integer that is the number of the pipeline.
-        :param dev_index: The number of the camera device.
+        :param dev_index: An integer that is the number of the camera device.
         :return: A boolean that tells if the pipeline is currently streaming
             the device.
         """
@@ -414,17 +416,14 @@ class PipelineManager:
         )
 
     def _stop_all_pipelines_using_this_device(self, dev_index: int) -> None:
-        """Stops streams of all pipelines that are streaming a particular
+        """
+        Stops streams of all pipelines that are streaming a particular
         device.
 
         This function is called when the device has errored.
 
-        Args:
-            dev_index: An integer that makes a pipeline stop streaming if it
+        :param dev_index: An integer that makes a pipeline stop streaming if it
             currently streaming that device number.
-
-        Returns:
-            None.
         """
         self._close_video_source(dev_index)
         for pipeline in self._pipelines:

--- a/src/esw/cameras/cameras.py
+++ b/src/esw/cameras/cameras.py
@@ -184,13 +184,8 @@ class PipelineManager:
             "cameras/max_video_device_id_number"
         )
 
-        self._mission_ips_map = {}
-        self._mission_res_map = {}
-        for missions_map in rospy.get_param("cameras/missions").items():
-            mission_name = missions_map['name']
-            self._mission_ips_map[mission_name] = missions_map['ips']
-            self._mission_res_map[mission_name] = missions_map['resolution']
-
+        self._update_mission_ips_and_res_maps()
+        
         self._current_mission = self._default_mission
         self._video_sources = [None] * self._max_vid_dev_id_number
         number_of_pipelines = rospy.get_param(
@@ -204,6 +199,26 @@ class PipelineManager:
         self._update_all_resolution_arguments()
         self._update_all_ips()
         self._update_all_video_outputs()
+
+    def _update_mission_ips_and_res_maps(self) -> None:
+        """Fills in mission ips and resolutions maps from cameras.yaml
+        Returns nothing.
+
+        Args:
+            None.
+
+        Returns:
+            None.
+        """
+        self._mission_ips_map = {}
+        self._mission_res_map = {}
+        # missions_map: dict
+        for missions_map in rospy.get_param("cameras/missions"):
+            mission_name = missions_map['name']
+            # streams_map: list
+            for streams_map in missions_map['streams']:
+                self._mission_ips_map[mission_name] = streams_map['endpoint']
+                self._mission_res_map[mission_name] = missions_map['resolution']
 
     def handle_change_camera_mission(
         self, req: ChangeCameraMissionRequest

--- a/src/esw/cameras/cameras.py
+++ b/src/esw/cameras/cameras.py
@@ -8,7 +8,7 @@ quality, and to which IPs.
 
 """
 import sys
-from typing import List
+from typing import List, TypedDict
 
 import rospy
 from mrover.srv import (ChangeCameraMission, ChangeCameraMissionRequest,
@@ -167,10 +167,10 @@ class PipelineManager:
     _current_mission: str
     _default_mission: str
     _max_vid_dev_id_number: int
-    _mission_ips_map: dict[str, str]
-    _mission_res_map: dict[str, int]
+    _mission_ips_map: TypedDict[str, str]
+    _mission_res_map: TypedDict[str, int]
     _pipelines: List[Pipeline]
-    _res_args_map: dict[int, List[str]]
+    _res_args_map: TypedDict[int, List[str]]
     _video_sources: List[jetson.utils.videoSource]
 
     def __init__(self) -> None:


### PR DESCRIPTION
Change the code so the config file has custom resolution for each endpoint. 

This is of interest since example: for the science mission, we might want different endpoints on one laptop than on another.