### PR TITLE
Add lock

### DIFF
--- a/src/esw/cameras/README.md
+++ b/src/esw/cameras/README.md
@@ -172,6 +172,7 @@ Actual behavior: The program freezes (presumably on the Capture function).
 ---
 
 ## TODO
+- [ ] Test to make sure that locks don't slow down or bug out the program.
 - [ ] Test the following: Are we allowed to copy a jetson.utils.videoSource object? I forgot behavior. Once this is found out, add to documentation/README.
 - [ ] Test the following: Test what happens when the one input device is being requested to be used for multiple output streams that differ in the resolution that it requests. Does the program fail and error?
 - [ ] Test the following: If an invalid device is being requested, does the response actually say -1 or does it not? Basically, does it only realize the device is invalid too late, as in after it sends the response?

--- a/src/esw/cameras/README.md
+++ b/src/esw/cameras/README.md
@@ -172,6 +172,7 @@ Actual behavior: The program freezes (presumably on the Capture function).
 ---
 
 ## TODO
+- [ ] Test the following: Are we allowed to copy a jetson.utils.videoSource object? I forgot behavior. Once this is found out, add to documentation/README.
 - [ ] Test the following: Test what happens when the one input device is being requested to be used for multiple output streams that differ in the resolution that it requests. Does the program fail and error?
 - [ ] Test the following: If an invalid device is being requested, does the response actually say -1 or does it not? Basically, does it only realize the device is invalid too late, as in after it sends the response?
 - [ ] Make sure that code makes logical sense... I'm reading through logic and head hurts

--- a/src/esw/cameras/cameras.py
+++ b/src/esw/cameras/cameras.py
@@ -34,8 +34,8 @@ class Pipeline:
         its input. -1 means it is not assigned any device.
         _video_output: A jetson.utils.videoOutput object that holds its output
         info.
-        _video_source: A jetson.utils.videoSource object that holds the video
-        source info.
+        _video_sources: A jetson.utils.videoSource object that holds the video
+        sources info.
     """
     arguments: List[str]
     current_ip: str

--- a/src/esw/cameras/cameras.py
+++ b/src/esw/cameras/cameras.py
@@ -33,33 +33,32 @@ class Pipeline:
         its input. -1 means it is not assigned any device.
     :var _video_output: A jetson.utils.videoOutput object that holds its output
         info.
-    :var _video_sources: A list of jetson.utils.videoSource objects that hold
-        the video source info.
     """
     arguments: List[str]
     current_endpoint: str
     _device_number: int
     _video_output: jetson.utils.videoOutput
-    _video_sources: List[jetson.utils.videoSource]
 
     def __init__(self) -> None:
         self.arguments = []
         self.current_endpoint = ""
         self.device_number = -1
         self._video_output = None
-        self._video_sources = []
 
-    def capture_and_render_image(self) -> bool:
+    def capture_and_render_image(
+        self, video_sources: List[jetson.utils.videoSource]
+    ) -> bool:
         """Captures an image from the video device and streams it. Returns
         boolean that is the success of capture and render.
 
         An exception will be caught if the program is unable to capture or
         render while streaming. In this case, False will be returned.
 
+        :param video_sources: A list of jetson.utils.videoSource's.
         :return: A boolean that is the success of capture and render.
         """
         try:
-            image = self._video_sources[self._device_number].Capture()
+            image = video_sources[self._device_number].Capture()
             self._video_output.Render(image)
             return True
         except Exception:
@@ -74,26 +73,15 @@ class Pipeline:
         """
         return self.device_number != -1
 
-    def link_video_sources(
-        self, video_sources: List[jetson.utils.videoSource]
-    ) -> None:
-        """Copies the reference of a list of video sources to a local variable.
-
-        Note that this is a reference since a list was assigned to a variable.
-        This means that self._video_sources can be modified outside of this
-        Pipeline object.
-
-        :param video_sources: A list of jetson.utils.videoSource's.
-        """
-        self._video_sources = video_sources
-
     def stop_streaming(self) -> None:
         """Stops streaming a camera device. This means that the pipeline is
             not assigned to a camera device.
         """
         self.device_number = -1
 
-    def update_device_number(self, dev_index: int) -> None:
+    def update_device_number(
+        self, dev_index: int, video_sources: List[jetson.utils.videoSource]
+    ) -> None:
         """Assigns the pipeline a camera device. This will also recreate the
         video output for in case the camera device resolution changes. If the
         camera device does not exist or if the request is -1, it will not be
@@ -101,10 +89,11 @@ class Pipeline:
 
         :param dev_index: An integer that is the camera device that it is
             assigned.
+        :param video_sources: A list of jetson.utils.videoSource's.
         """
         self.device_number = dev_index
         if dev_index != -1:
-            if self._video_sources[self._device_number] is not None:
+            if video_sources[self._device_number] is not None:
                 self.update_video_output()
             else:
                 print(
@@ -175,7 +164,6 @@ class PipelineManager:
         for pipe_index in range(len(self._pipelines)):
             self._pipelines[pipe_index] = Pipeline()
 
-        self._update_all_video_source_links()
         self._update_all_resolution_arguments()
         self._update_all_endpoints()
         self._update_all_video_outputs()
@@ -246,7 +234,9 @@ class PipelineManager:
         """
         for pipe_index, pipeline in enumerate(self._pipelines):
             if pipeline.is_currently_streaming():
-                success = pipeline.capture_and_render_image()
+                success = pipeline.capture_and_render_image(
+                    self._video_sources
+                )
                 if not success:
                     self._clean_up_failed_pipeline(pipe_index)
 
@@ -403,7 +393,9 @@ class PipelineManager:
         :param pipe_index: An integer that is the number of the pipeline
             that is being assigned a camera device.
         """
-        self._pipelines[pipe_index].update_device_number(dev_index)
+        self._pipelines[pipe_index].update_device_number(
+            dev_index, self._video_sources
+        )
         print(
             f"Playing camera {dev_index} on \
             {self._get_endpoint(pipe_index)}."
@@ -463,12 +455,6 @@ class PipelineManager:
             if pipe_index == 0 or pipe_index == 1:
                 continue
             pipeline.update_video_output()
-
-    def _update_all_video_source_links(self) -> None:
-        """Updates the links of all pipelines to the global video source.
-        """
-        for pipeline in self._pipelines:
-            pipeline.link_video_sources(self._video_sources)
 
     def _update_mission(self, mission_name: str) -> None:
         """Updates the mission name.

--- a/src/esw/cameras/cameras.py
+++ b/src/esw/cameras/cameras.py
@@ -30,20 +30,24 @@ class Pipeline:
     :var arguments: A list of strings that is needed for the jetson.utils
         objects' capture arguments.
     :var current_endpoint: A string that is endpoint it is assigned to.
-    :var _device_number: An int that is the device number it is assigned to as
+    :var device_number: An int that is the device number it is assigned to as
         its input. -1 means it is not assigned any device.
+    :var _device_number_lock: A lock used to prevent threads from accessing
+        shared variables such as device_number at the same time.
     :var _video_output: A jetson.utils.videoOutput object that holds its output
         info.
     """
     arguments: List[str]
     current_endpoint: str
-    _device_number: int
+    device_number: int
+    _device_number_lock: threading.Lock
     _video_output: jetson.utils.videoOutput
 
     def __init__(self) -> None:
         self.arguments = []
         self.current_endpoint = ""
         self.device_number = -1
+        self._device_number_lock = threading.Lock()
         self._video_output = None
 
     def capture_and_render_image(
@@ -72,13 +76,18 @@ class Pipeline:
         :return: A boolean that returns True if the pipeline is assigned an
             active camera device.
         """
-        return self.device_number != -1
+        self._device_number_lock.acquire()
+        is_streaming = self.device_number != -1
+        self._device_number_lock.release()
+        return is_streaming
 
     def stop_streaming(self) -> None:
         """Stops streaming a camera device. This means that the pipeline is
             not assigned to a camera device.
         """
+        self._device_number_lock.acquire()
         self.device_number = -1
+        self._device_number_lock.release()
 
     def update_device_number(
         self, dev_index: int, video_sources: List[jetson.utils.videoSource]
@@ -92,7 +101,9 @@ class Pipeline:
             assigned.
         :param video_sources: A list of jetson.utils.videoSource's.
         """
+        self._device_number_lock.acquire()
         self.device_number = dev_index
+        self._device_number_lock.release()
         if dev_index != -1:
             if video_sources[self._device_number] is not None:
                 self.update_video_output()
@@ -107,10 +118,16 @@ class Pipeline:
         """Updates the video output to ensure that pipeline is streaming to
         the assigned endpoint and has the proper arguments.
         """
-        self._video_output = jetson.utils.videoOutput(
-            f"rtp://{self.current_endpoint}",
-            argv=self.arguments
-        )
+        try:
+            self._video_output = jetson.utils.videoOutput(
+                f"rtp://{self.current_endpoint}",
+                argv=self.arguments
+            )
+        except Exception:
+            print(
+                f"Update video output failed on endpoint \
+                {self.current_endpoint}."
+            )
 
 
 class PipelineManager:
@@ -131,8 +148,8 @@ class PipelineManager:
         of a device to an IP.
     :var _res_args_map: A dictionary that maps a resolution quality to a list
         of arguments needed for jetson.utils.
-    :var _video_lock: A lock used to prevent threads from accessing shared
-        variables such as _video_sources at the same time.
+    :var _video_source_lock: A lock used to prevent threads from accessing
+        shared variables such as _video_sources at the same time.
     :var _video_sources: A list of jetson.utils.videoSource's.
     """
     _active_cameras: List[int]
@@ -142,7 +159,7 @@ class PipelineManager:
     _mission_streams_map: 'Dict[str, List[Dict[str, str | int]]]'
     _pipelines: List[Pipeline]
     _res_args_map: Dict[int, List[str]]
-    _video_lock: threading.Lock
+    _video_source_lock: threading.Lock
     _video_sources: List[jetson.utils.videoSource]
 
     def __init__(self) -> None:
@@ -159,7 +176,7 @@ class PipelineManager:
         self._update_mission_streams_map()
 
         self._current_mission = self._default_mission
-        self._video_lock = threading.Lock()
+        self._video_source_lock = threading.Lock()
         self._video_sources = [None] * self._max_vid_dev_id_number
         number_of_pipelines = rospy.get_param(
             "cameras/number_of_pipelines"
@@ -239,9 +256,11 @@ class PipelineManager:
         """
         for pipe_index, pipeline in enumerate(self._pipelines):
             if pipeline.is_currently_streaming():
+                self._video_source_lock.acquire()
                 success = pipeline.capture_and_render_image(
                     self._video_sources
                 )
+                self._video_source_lock.release()
                 if not success:
                     self._clean_up_failed_pipeline(pipe_index)
 
@@ -291,7 +310,9 @@ class PipelineManager:
         :param dev_index: An integer that is the number of the video camera
             device that is being closed.
         """
+        self._video_source_lock.acquire()
         self._video_sources[dev_index] = None
+        self._video_source_lock.release()
 
     def _create_video_source_for_pipe_if_possible(
         self, dev_index: int, pipe_index: int
@@ -310,15 +331,18 @@ class PipelineManager:
         """
         if dev_index == -1:
             return
-        if self._video_sources[dev_index] is not None:
-            return
         try:
+            self._video_source_lock.acquire()
+            if self._video_sources[dev_index] is not None:
+                return
             self._video_sources[dev_index] = jetson.utils.videoSource(
                 f"/dev/video{dev_index}",
                 argv=self._get_pipe_arguments(pipe_index)
             )
         except Exception:
             return
+        finally:
+            self._video_source_lock.release()
 
     def _get_all_streams(self) -> 'List[Dict[str, str | int]]':
         """Returns a list of all the streams.
@@ -398,9 +422,11 @@ class PipelineManager:
         :param pipe_index: An integer that is the number of the pipeline
             that is being assigned a camera device.
         """
+        self._video_source_lock.acquire()
         self._pipelines[pipe_index].update_device_number(
             dev_index, self._video_sources
         )
+        self._video_source_lock.release()
         print(
             f"Playing camera {dev_index} on \
             {self._get_endpoint(pipe_index)}."

--- a/src/esw/cameras/cameras.py
+++ b/src/esw/cameras/cameras.py
@@ -8,6 +8,7 @@ quality, and to which IPs.
 
 """
 import sys
+import threading
 from typing import List
 
 import rospy
@@ -161,6 +162,8 @@ class PipelineManager:
         of a device to an IP.
         _res_args_map: A dictionary that maps a resolution quality to a list
         of arguments needed for jetson.utils.
+        _video_lock: A lock used to prevent threads from accessing shared
+        variables such as _video_sources at the same time.
         _video_sources: A list of jetson.utils.videoSource's.
     """
     _active_cameras: List[int]
@@ -171,6 +174,7 @@ class PipelineManager:
     _mission_res_map: dict[str, int]
     _pipelines: List[Pipeline]
     _res_args_map: dict[int, List[str]]
+    _video_lock: threading.Lock
     _video_sources: List[jetson.utils.videoSource]
 
     def __init__(self) -> None:
@@ -192,6 +196,7 @@ class PipelineManager:
             self._mission_res_map[mission_name] = missions_map['resolution']
 
         self._current_mission = self._default_mission
+        self._video_lock = threading.Lock()
         self._video_sources = [None] * self._max_vid_dev_id_number
         number_of_pipelines = rospy.get_param(
             "cameras/number_of_pipelines"

--- a/src/esw/cameras/cameras.py
+++ b/src/esw/cameras/cameras.py
@@ -467,7 +467,7 @@ class PipelineManager:
     def _update_all_video_source_links(self) -> None:
         """Updates the links of all pipelines to the global video source.
         """
-        for  pipeline in self._pipelines:
+        for pipeline in self._pipelines:
             pipeline.link_video_sources(self._video_sources)
 
     def _update_mission(self, mission_name: str) -> None:


### PR DESCRIPTION
A lock should be added to prevent different threads from modifying and reading from PipelineManager's _video_sources at the same time.