### PR TITLE
State literal type explicitly

### DIFF
--- a/src/esw/motors/Controller.cpp
+++ b/src/esw/motors/Controller.cpp
@@ -38,7 +38,7 @@ void Controller::make_live() {
         }
 
         // get value in quad counts adjust quadrature encoder
-        int32_t adjusted_quad = (abs_raw_angle / (2 * M_PI)) * quad_cpr;
+        int32_t adjusted_quad = (abs_raw_angle / (2.0f * M_PI)) * quad_cpr;
         memcpy(buffer, UINT8_POINTER_T(&(adjusted_quad)), sizeof(adjusted_quad));
         transact(ADJUST, buffer, nullptr);
 
@@ -62,7 +62,7 @@ void Controller::make_live() {
 void Controller::record_angle(int32_t raw_angle) {
     // record quadrature
     current_angle_m.lock();
-    current_angle = ((raw_angle / quad_cpr) * 2 * M_PI) - M_PI;
+    current_angle = ((raw_angle / quad_cpr) * 2.0f * M_PI) - M_PI;
     current_angle_m.unlock();
 }
 
@@ -121,7 +121,6 @@ void Controller::calibrate_joint() {
 void Controller::closed_loop(float torque, float target) {
     try {
         make_live();
-
         // TODO - UNCOMMENT ONCE LIMIT SWITCHES ARE IMPLEMENTED
         /*
         refresh_calibration_data();
@@ -131,8 +130,10 @@ void Controller::closed_loop(float torque, float target) {
             return;
         }
         */
-
-        float feed_forward = 0; // torque * torque_scale;
+        // TODO - INVESTIGATE IF parameter torque IS NEEDED. if not, then we should just get rid
+        // of it and simplify
+        // the function to closed_loop(float target). 
+        float feed_forward = 0.0f; // torque * torque_scale;
         uint8_t buffer[32];
         int32_t angle;
         memcpy(buffer, UINT8_POINTER_T(&feed_forward), sizeof(feed_forward));
@@ -140,7 +141,7 @@ void Controller::closed_loop(float torque, float target) {
         // we read values from 0 - 2pi, teleop sends in -pi to pi
         target += M_PI;
 
-        int32_t closed_setpoint = static_cast<int32_t>((target / (2.0 * M_PI)) * quad_cpr);
+        int32_t closed_setpoint = static_cast<int32_t>((target / (2.0f * M_PI)) * quad_cpr);
         memcpy(buffer + 4, UINT8_POINTER_T(&closed_setpoint), sizeof(closed_setpoint));
 
         transact(CLOSED_PLUS, buffer, UINT8_POINTER_T(&angle));
@@ -192,7 +193,7 @@ void Controller::open_loop(float input) {
         refresh_calibration_data();
         if ((name == "ARM_B" || name == "SA_B") && !calibrated)
         {
-            printf("closed_loop failed because joint B is not yet calibrated");
+            printf("open_loop failed because joint B is not yet calibrated");
             return;
         }
         */
@@ -202,8 +203,10 @@ void Controller::open_loop(float input) {
 
         // When closing the gripper, we want 0.84 * 12 V = 10 V.
         // Closing is currently when speed is positive
+        // TODO - make this more configurable for what we want closing
+        // gripper voltage to be.
         if (name == "HAND_GRIP") {
-            speed = speed > 0.84 ? 0.84 : speed;
+            speed = speed > 0.84f ? 0.84f : speed;
         }
 
 

--- a/src/esw/motors/Controller.cpp
+++ b/src/esw/motors/Controller.cpp
@@ -29,7 +29,7 @@ void Controller::make_live() {
         // get absolute encoder correction #
         // not needed for joint F
 
-        float abs_raw_angle = 0;
+        float abs_raw_angle = 0.0f;
 
         if (name == "ARM_B" || name == "SA_B" || name == "ARM_F") {
             abs_raw_angle = M_PI;
@@ -67,7 +67,7 @@ void Controller::record_angle(int32_t raw_angle) {
 }
 
 float Controller::get_current_angle() {
-    float return_angle = 0.0;
+    float return_angle = 0.0f;
     current_angle_m.lock();
     return_angle = current_angle;
     current_angle_m.unlock();

--- a/src/esw/motors/Controller.h
+++ b/src/esw/motors/Controller.h
@@ -41,16 +41,16 @@ sent. This is to prevent multiple virtual Controller objects from trying to cont
 
 class Controller {
 public:
-    float start_angle = 0.0;
-    float torque_scale = 1.0;
+    float start_angle = 0.0f;
+    float torque_scale = 1.0f;
     float quad_cpr = std::numeric_limits<float>::infinity();
-    float current_angle = 0.0;
-    float kP = 0.01;
-    float kI = 0.0;
-    float kD = 0.0;
+    float current_angle = 0.0f;
+    float kP = 0.01f;
+    float kI = 0.0f;
+    float kD = 0.0f;
     bool calibrated = false;
     int inversion = 1;
-    float last_speed = 0;
+    float last_speed = 0.0f;
 
     std::string name;
     std::mutex current_angle_m;

--- a/src/esw/motors/Hardware.h
+++ b/src/esw/motors/Hardware.h
@@ -45,6 +45,10 @@ public:
 
     Hardware(std::string input) : type(getType(input)) {
         switch (type) {
+            // TODO - make it more configurable what numbers we need
+            // Can do this by having a "desired voltage" and "input voltage"
+            // e.g. HBridge is 100 since it has desired volt of 12V and input of 12V
+            // e.g. Motor 9V is 25 because desired is 9V and input is 36V
             case Motor6V:
                 speed_max = 16; // 5.76 V
                 break;
@@ -78,10 +82,10 @@ public:
 
     //limits throttle
     float throttle(float input) {
-        if (input > 1.0) {
-            input = 1.0;
-        } else if (input < -1.0) {
-            input = -1.0;
+        if (input > 1.0f) {
+            input = 1.0f;
+        } else if (input < -1.0f) {
+            input = -1.0f;
         }
         return input;
     }

--- a/src/esw/motors/ROSHandler.cpp
+++ b/src/esw/motors/ROSHandler.cpp
@@ -66,12 +66,12 @@ void ROSHandler::handle_outgoing() {
 
 // The following functions are handlers for the corresponding ROS messages
 void ROSHandler::InternalHandler::arm_closed_loop_cmd(mrover::ArmPosition& msg) {
-    ControllerMap::controllers["ARM_A"]->closed_loop(0, msg->joint_a);
-    ControllerMap::controllers["ARM_B"]->closed_loop(0, msg->joint_b);
-    ControllerMap::controllers["ARM_C"]->closed_loop(0, msg->joint_c);
-    ControllerMap::controllers["ARM_D"]->closed_loop(0, msg->joint_d);
-    ControllerMap::controllers["ARM_E"]->closed_loop(0, msg->joint_e);
-    ControllerMap::controllers["ARM_F"]->closed_loop(0, msg->joint_f);
+    ControllerMap::controllers["ARM_A"]->closed_loop(0.0f, msg->joint_a);
+    ControllerMap::controllers["ARM_B"]->closed_loop(0.0f, msg->joint_b);
+    ControllerMap::controllers["ARM_C"]->closed_loop(0.0f, msg->joint_c);
+    ControllerMap::controllers["ARM_D"]->closed_loop(0.0f, msg->joint_d);
+    ControllerMap::controllers["ARM_E"]->closed_loop(0.0f, msg->joint_e);
+    ControllerMap::controllers["ARM_F"]->closed_loop(0.0f, msg->joint_f);
     publish_arm_pos_data();
 }
 
@@ -87,7 +87,7 @@ void ROSHandler::InternalHandler::arm_open_loop_cmd(mrover::ArmOpenLoopCmd& msg)
 }
 
 void ROSHandler::InternalHandler::carousel_closed_loop_cmd(mrover::CarouselPosition& msg) {
-    ControllerMap::controllers["CAROUSEL_MOTOR"]->closed_loop(0, msg->position);
+    ControllerMap::controllers["CAROUSEL_MOTOR"]->closed_loop(0.0f, msg->position);
 }
 
 void ROSHandler::InternalHandler::carousel_open_loop_cmd(mrover::CarouselOpenLoopCmd& msg) {
@@ -157,10 +157,10 @@ void ROSHandler::InternalHandler::refresh_sa_quad_angles() {
 }
 
 void ROSHandler::InternalHandler::sa_closed_loop_cmd(mrover::SAPosition& msg) {
-    ControllerMap::controllers["SA_A"]->closed_loop(0, msg->joint_a);
-    ControllerMap::controllers["SA_B"]->closed_loop(0, msg->joint_b);
-    ControllerMap::controllers["SA_C"]->closed_loop(0, msg->joint_c);
-    ControllerMap::controllers["SA_E"]->closed_loop(0, msg->joint_e);
+    ControllerMap::controllers["SA_A"]->closed_loop(0.0f, msg->joint_a);
+    ControllerMap::controllers["SA_B"]->closed_loop(0.0f, msg->joint_b);
+    ControllerMap::controllers["SA_C"]->closed_loop(0.0f, msg->joint_c);
+    ControllerMap::controllers["SA_E"]->closed_loop(0.0f, msg->joint_e);
 
     publish_sa_pos_data();
 }


### PR DESCRIPTION
Apparently it's just better practice to state the literal type explicitly