### PR TITLE
Separate spectral and triad

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ add_message_files(
         Heater.msg
         Spectral.msg
         Thermistor.msg
+        Triad.msg
         Waypoint.msg
 )
 

--- a/msg/Spectral.msg
+++ b/msg/Spectral.msg
@@ -1,1 +1,2 @@
-int32[18] data
+string site
+int32[6] data

--- a/src/esw/science_board/README.md
+++ b/src/esw/science_board/README.md
@@ -139,7 +139,7 @@ Publisher: science_board \
 Subscriber: gui
 
 #### Spectral Triad Data
-Message: [`Spectral.msg`](../../../msg/Spectral.msg) "science/spectral_triad_data" \
+Message: [`Triad.msg`](../../../msg/Triad.msg) "science/spectral_triad_data" \
 Publisher: science_board \
 Subscriber: gui
 

--- a/src/esw/science_board/README.md
+++ b/src/esw/science_board/README.md
@@ -168,9 +168,9 @@ Subscriber: gui
 - The device represents the MOSFET device being activated (0 to 11)
 
 #### Spectral Data
-- `$SPECTRAL, d0_msb_ch0, d0_lsb_ch0, d0_msb_ch1, d0_lsb_ch1, d0_msb_ch2, d0_lsb_ch2, d0_msb_ch3, d0_lsb_ch3, d0_msb_ch4, d0_lsb_ch4, d0_msb_ch5, d0_lsb_ch5, d1_msb_ch0, d1_lsb_ch0, d1_msb_ch1, d1_lsb_ch1, d1_msb_ch2, d1_lsb_ch2, d1_msb_ch3, d1_lsb_ch3, d1_msb_ch4, d1_lsb_ch4, d1_msb_ch5, d1_lsb_ch5,  d2_msb_ch0, d2_lsb_ch0, d2_msb_ch1, d2_lsb_ch1, d2_msb_ch2, d2_lsb_ch2, d2_msb_ch3, d2_lsb_ch3, d2_msb_ch4, d2_lsb_ch4, d2_msb_ch5, d2_lsb_ch5,<extra padding>`
-- Data is 155 characters long
-- 6 channel data from each of the three spectrals
+- `$SPECTRAL, site, msb_ch0, lsb_ch0, msb_ch1, lsb_ch1, msb_ch2, lsb_ch2, msb_ch3, lsb_ch3, msb_ch4, lsb_ch4, d0_msb_ch5, lsb_ch5, <extra padding>`
+- Data is 155 characters long (probably will change tbh)
+- 6 channel data from a spectral
 
 #### Servo Cmd
 - `$SERVO,<angle_0>,<angle_1>,<angle_2>,<extra padding>`
@@ -190,6 +190,7 @@ Subscriber: gui
 ---
 
 ## TODO
+- [ ] IMPORTANT - UPDATE SPECTRAL NMEA MESSAGE IN HARDWARE, make sure to also maybe change length of msg
 - [ ] simplify the mapper logic (can put into a function instead), don't need both _handler_function_by_tag and _ros_publisherr_by_tag probably
 - [ ] Analyze behavior when MOSFET device is out of bounds. See if it should be handled by firmware or here or both.
 It is preferred if it is both, but this program does not currently have any checking.

--- a/src/esw/science_board/science_board.py
+++ b/src/esw/science_board/science_board.py
@@ -423,8 +423,9 @@ class ScienceBridge():
         :param tx_msg: A string that was received from UART that contains data
             of the three carousel spectral sensors.
             - Format: <"SPECTRAL,site,ch_0,ch_1,....ch_5">
-        :returns: A Spectral struct that has the site of the spectral and six
-            floats that is the data of the a carousel spectral sensor.
+        :returns: A Spectral struct that has a string that is the site of the
+            spectral and six floats that is the data of the a carousel
+            spectral sensor.
         """
         tx_msg.split(',')
         arr = [s.strip().strip('\x00') for s in tx_msg.split(',')]

--- a/src/esw/science_board/science_board.py
+++ b/src/esw/science_board/science_board.py
@@ -479,7 +479,7 @@ class ScienceBridge():
         """
         tx_msg.split(',')
         arr = [s.strip().strip('\x00') for s in tx_msg.split(',')]
-        ros_msg = Spectral()
+        ros_msg = Triad()
         count = 1
         for index in range(len(ros_msg.data)):
             if not count >= len(arr):

--- a/src/esw/science_board/science_board.py
+++ b/src/esw/science_board/science_board.py
@@ -15,7 +15,7 @@ from typing import Any, Callable, Dict, List
 import numpy as np
 import rospy
 import serial
-from mrover.msg import Enable, Heater, Spectral, Thermistor
+from mrover.msg import Enable, Heater, Spectral, Thermistor, Triad
 from mrover.srv import (ChangeAutonLEDState, ChangeAutonLEDStateRequest,
                         ChangeAutonLEDStateResponse, ChangeDeviceState,
                         ChangeDeviceStateRequest, ChangeDeviceStateResponse,
@@ -37,7 +37,7 @@ class ScienceBridge():
         struct with the packaged data.
     :param _mosfet_number_by_device_name: A dictionary that maps each actual
         device to a MOSFET device number.
-    :param _ros_publisherr_by_tag: A dictionary that maps each NMEA tag for a
+    :param _ros_publisher_by_tag: A dictionary that maps each NMEA tag for a
         UART message to its corresponding ROS Publisher object.
     :param _sleep: A float representing the sleep duration used for when the
         sleep function is called.
@@ -49,7 +49,7 @@ class ScienceBridge():
     _id_by_color: Dict[str, int]
     _handler_function_by_tag: Dict[str, Callable[[str], Any]]
     _mosfet_number_by_device_name: Dict[str, int]
-    _ros_publisherr_by_tag: Dict[str, rospy.Publisher]
+    _ros_publisher_by_tag: Dict[str, rospy.Publisher]
     _sleep: float
     _uart_transmit_msg_len: int
     _uart_lock: threading.Lock
@@ -65,7 +65,7 @@ class ScienceBridge():
             "THERMISTOR": self._thermistor_handler,
             "TRIAD": self._triad_handler
         }
-        self._ros_publisherr_by_tag = {
+        self._ros_publisher_by_tag = {
             "AUTOSHUTOFF": rospy.Publisher(
                 'science/heater_auto_shut_off_data', Enable, queue_size=1),
             "HEATER": rospy.Publisher(
@@ -226,7 +226,7 @@ class ScienceBridge():
                 print(tx_msg)
                 match_found = True
                 ros_msg: Any = handler_func(tx_msg)
-                self._ros_publisherr_by_tag[tag].publish(ros_msg)
+                self._ros_publisher_by_tag[tag].publish(ros_msg)
                 break
         if (not match_found) and (not tx_msg):
             print(f'Error decoding message stream: {tx_msg}')
@@ -416,19 +416,21 @@ class ScienceBridge():
         spectral sensors and packages it into a ROS struct.
 
         There are 3 spectral sensors, each having 6 channels. We read a
-        uint16_t from each channel. The Jetson reads byte by byte, so the
-        program combines every two bytes of information into a uint16_t.
+        uint16_t from each channel. We know which sensor is which because we
+        know what the site is. The Jetson reads byte by byte, so the program
+        combines every two bytes of information into a uint16_t.
 
         :param tx_msg: A string that was received from UART that contains data
             of the three carousel spectral sensors.
-            - Format: <"SPECTRAL,ch_0_0,ch_0_1,....ch_2_5">
-        :returns: A Spectral struct that has 18 floats that is the data of the
-            three carousel spectral sensors.
+            - Format: <"SPECTRAL,site,ch_0,ch_1,....ch_5">
+        :returns: A Spectral struct that has the site of the spectral and six
+            floats that is the data of the a carousel spectral sensor.
         """
         tx_msg.split(',')
         arr = [s.strip().strip('\x00') for s in tx_msg.split(',')]
         ros_msg = Spectral()
-        count = 1
+        ros_msg.site = arr[1]
+        count = 2
         for index in range(len(ros_msg.data)):
             if not count >= len(arr):
                 ros_msg.data[index] = 0xFFFF & (

--- a/src/esw/science_board/science_board.py
+++ b/src/esw/science_board/science_board.py
@@ -75,7 +75,7 @@ class ScienceBridge():
             "THERMISTOR": rospy.Publisher(
                 'science/thermistor_data', Thermistor, queue_size=1),
             "TRIAD": rospy.Publisher(
-                'science/spectral_triad_data', Spectral, queue_size=1)
+                'science/spectral_triad_data', Triad, queue_size=1)
         }
         self._sleep = rospy.get_param("/science_board/info/sleep")
         self._uart_transmit_msg_len = rospy.get_param(


### PR DESCRIPTION
Not sure if this is better but my thought was that even though spectral and triad are VERY similar, it might be worth making a new msg just for spectral so that it's more clear which data is for which spectral.

This is all assuming we have three spectral sensors.
For publishing spectral data, we can do either of the following: 
1. Publish spectral data to 3 different topics
2. Publish spectral data to the same topic but have the msg consist of the particular sensor (I don't like this idea as much)

I think we'll probably go with option 2, it seems easier