### PR TITLE
Change joint msg to array

### DIFF
--- a/msg/ArmPosition.msg
+++ b/msg/ArmPosition.msg
@@ -1,6 +1,1 @@
-float64 joint_a
-float64 joint_b
-float64 joint_c
-float64 joint_d
-float64 joint_e
-float64 joint_f
+float64[6] joints

--- a/src/esw/motors/ROSHandler.cpp
+++ b/src/esw/motors/ROSHandler.cpp
@@ -66,12 +66,12 @@ void ROSHandler::handle_outgoing() {
 
 // The following functions are handlers for the corresponding ROS messages
 void ROSHandler::InternalHandler::arm_closed_loop_cmd(mrover::ArmPosition& msg) {
-    ControllerMap::controllers["ARM_A"]->closed_loop(0.0f, msg->joint_a);
-    ControllerMap::controllers["ARM_B"]->closed_loop(0.0f, msg->joint_b);
-    ControllerMap::controllers["ARM_C"]->closed_loop(0.0f, msg->joint_c);
-    ControllerMap::controllers["ARM_D"]->closed_loop(0.0f, msg->joint_d);
-    ControllerMap::controllers["ARM_E"]->closed_loop(0.0f, msg->joint_e);
-    ControllerMap::controllers["ARM_F"]->closed_loop(0.0f, msg->joint_f);
+    ControllerMap::controllers["ARM_A"]->closed_loop(0.0f, msg->joints[0]);
+    ControllerMap::controllers["ARM_B"]->closed_loop(0.0f, msg->joints[1]);
+    ControllerMap::controllers["ARM_C"]->closed_loop(0.0f, msg->joints[2]);
+    ControllerMap::controllers["ARM_D"]->closed_loop(0.0f, msg->joints[3]);
+    ControllerMap::controllers["ARM_E"]->closed_loop(0.0f, msg->joints[4]);
+    ControllerMap::controllers["ARM_F"]->closed_loop(0.0f, msg->joints[5]);
     publish_arm_pos_data();
 }
 

--- a/src/esw/motors/ROSHandler.cpp
+++ b/src/esw/motors/ROSHandler.cpp
@@ -207,12 +207,12 @@ void ROSHandler::InternalHandler::publish_arm_calib_data() {
 
 void ROSHandler::InternalHandler::publish_arm_pos_data() {
     mrover::ArmPosition msg;
-    msg.joint_a = ControllerMap::controllers["ARM_A"]->get_current_angle();
-    msg.joint_b = ControllerMap::controllers["ARM_B"]->get_current_angle();
-    msg.joint_c = ControllerMap::controllers["ARM_C"]->get_current_angle();
-    msg.joint_d = ControllerMap::controllers["ARM_D"]->get_current_angle();
-    msg.joint_e = ControllerMap::controllers["ARM_E"]->get_current_angle();
-    msg.joint_f = ControllerMap::controllers["ARM_F"]->get_current_angle();
+    msg.joints[0] = ControllerMap::controllers["ARM_A"]->get_current_angle();
+    msg.joints[1] = ControllerMap::controllers["ARM_B"]->get_current_angle();
+    msg.joints[2] = ControllerMap::controllers["ARM_C"]->get_current_angle();
+    msg.joints[3] = ControllerMap::controllers["ARM_D"]->get_current_angle();
+    msg.joints[4] = ControllerMap::controllers["ARM_E"]->get_current_angle();
+    msg.joints[5] = ControllerMap::controllers["ARM_F"]->get_current_angle();
     arm_position_pub.publish(msg);
     last_heartbeat_output_time = NOW;
 }


### PR DESCRIPTION
It is probably easier for everyone if an array is used.

only problem is that the name of the joints aren't as explicit but OH WELL, we can just rename the joints to joints 0 1 2 3 4 5 next year instead of joints a b c d e f if it's that much of an issue xd